### PR TITLE
 Improve unit test coverage on AuditRoleManager

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## Version 2.1.0
+* Make the audit whitelist table a protected resource in Cassandra
+
 ## Version 2.0.0
 * __NOTE__: This version is breaking backwards compatibility - consult detailed instructions in the [upgrade guide](UPGRADING.md)
 * Add support for whitelists based on specific operations

--- a/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditRoleManager.java
+++ b/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditRoleManager.java
@@ -17,35 +17,41 @@ package com.ericsson.bss.cassandra.ecaudit.auth;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.auth.AuthKeyspace;
 import org.apache.cassandra.auth.AuthenticatedUser;
 import org.apache.cassandra.auth.CassandraRoleManager;
+import org.apache.cassandra.auth.DataResource;
 import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.IRoleManager;
-import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.auth.RoleOptions;
 import org.apache.cassandra.auth.RoleResource;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.RequestExecutionException;
 import org.apache.cassandra.exceptions.RequestValidationException;
 
 /**
- * Implements a {@link IRoleManager} that is meant to be paired with {@link AuditPasswordAuthenticator} and {@link AuditAuthorizer}.
+ * Implements a {@link IRoleManager} that is meant to be paired with {@link AuditPasswordAuthenticator} and
+ * {@link AuditAuthorizer}.
  *
- * It provides support for audit white-lists based on role options in Cassandra. This implementation inherits the
- * {@link CassandraRoleManager} for generic role management.
+ * It provides support for audit white-lists based on role options in Cassandra. This implementation is a decorator
+ * which wraps the {@link CassandraRoleManager} for generic role management.
  *
- * An explicit permission check is enforced on ALTER statements. This makes it possible to grant whitelists from one role to another.
+ * An explicit permission check is enforced on ALTER statements. This makes it possible to grant whitelists from one
+ * role to another.
  */
-public class AuditRoleManager extends CassandraRoleManager
+public class AuditRoleManager implements IRoleManager
 {
     private static final Logger LOG = LoggerFactory.getLogger(AuditRoleManager.class);
 
+    private final IRoleManager wrappedRoleManager;
     private final AuditWhitelistManager whitelistManager;
     private final PermissionChecker permissionChecker;
 
@@ -60,24 +66,48 @@ public class AuditRoleManager extends CassandraRoleManager
      */
     public AuditRoleManager()
     {
+        this(new CassandraRoleManager(),
+             new AuditWhitelistManager(),
+             DatabaseDescriptor.getAuthenticator() instanceof AuditPasswordAuthenticator);
+    }
+
+    @VisibleForTesting
+    AuditRoleManager(IRoleManager wrappedRoleManager, AuditWhitelistManager whitelistManager, boolean hasAuditPasswordAuthenticator)
+    {
         LOG.info("Auditing enabled on role manager");
 
-        whitelistManager = new AuditWhitelistManager();
+        this.wrappedRoleManager = wrappedRoleManager;
+        this.whitelistManager = whitelistManager;
         permissionChecker = new PermissionChecker();
 
-        supportedOptions = DatabaseDescriptor.getAuthenticator().getClass() == AuditPasswordAuthenticator.class
-                ? ImmutableSet.of(Option.LOGIN, Option.SUPERUSER, Option.PASSWORD, Option.OPTIONS)
-                : ImmutableSet.of(Option.LOGIN, Option.SUPERUSER);
-        alterableOptions = DatabaseDescriptor.getAuthenticator().getClass().equals(AuditPasswordAuthenticator.class)
-                ? ImmutableSet.of(Option.PASSWORD)
-                : ImmutableSet.of();
+        supportedOptions = hasAuditPasswordAuthenticator
+                           ? ImmutableSet.of(Option.LOGIN, Option.SUPERUSER, Option.PASSWORD, Option.OPTIONS)
+                           : ImmutableSet.of(Option.LOGIN, Option.SUPERUSER);
+        alterableOptions = hasAuditPasswordAuthenticator
+                           ? ImmutableSet.of(Option.PASSWORD)
+                           : ImmutableSet.of();
+    }
+
+    @Override
+    public void validateConfiguration() throws ConfigurationException
+    {
+        wrappedRoleManager.validateConfiguration();
     }
 
     @Override
     public void setup()
     {
-        super.setup();
-        WhitelistDataAccess.getInstance().setup();
+        wrappedRoleManager.setup();
+        whitelistManager.setup();
+    }
+
+    @Override
+    public Set<? extends IResource> protectedResources()
+    {
+        Set<IResource> combinedSet = Sets.newHashSet(wrappedRoleManager.protectedResources());
+        combinedSet.add(DataResource.table(AuthKeyspace.NAME, AuditAuthKeyspace.WHITELIST_TABLE_NAME_V1));
+        combinedSet.add(DataResource.table(AuthKeyspace.NAME, AuditAuthKeyspace.WHITELIST_TABLE_NAME_V2));
+        return ImmutableSet.copyOf(combinedSet);
     }
 
     @Override
@@ -94,10 +124,10 @@ public class AuditRoleManager extends CassandraRoleManager
 
     @Override
     public void createRole(AuthenticatedUser performer, RoleResource role, RoleOptions options)
-            throws RequestValidationException, RequestExecutionException
+    throws RequestValidationException, RequestExecutionException
     {
         whitelistManager.createRoleOption(options);
-        super.createRole(performer, role, options);
+        wrappedRoleManager.createRole(performer, role, options);
     }
 
     @Override
@@ -105,7 +135,7 @@ public class AuditRoleManager extends CassandraRoleManager
     {
         permissionChecker.checkAlterRoleAccess(performer, role, options);
         whitelistManager.alterRoleOption(performer, role, options);
-        super.alterRole(performer, role, options);
+        wrappedRoleManager.alterRole(performer, role, options);
     }
 
     @Override
@@ -115,10 +145,55 @@ public class AuditRoleManager extends CassandraRoleManager
     }
 
     @Override
-    public void dropRole(AuthenticatedUser performer, RoleResource role)
-            throws RequestValidationException, RequestExecutionException
+    public void grantRole(AuthenticatedUser performer, RoleResource role, RoleResource grantee)
+    throws RequestValidationException, RequestExecutionException
     {
-        super.dropRole(performer, role);
+        wrappedRoleManager.grantRole(performer, role, grantee);
+    }
+
+    @Override
+    public void revokeRole(AuthenticatedUser performer, RoleResource role, RoleResource revokee)
+    throws RequestValidationException, RequestExecutionException
+    {
+        wrappedRoleManager.revokeRole(performer, role, revokee);
+    }
+
+    @Override
+    public void dropRole(AuthenticatedUser performer, RoleResource role)
+    throws RequestValidationException, RequestExecutionException
+    {
+        wrappedRoleManager.dropRole(performer, role);
         whitelistManager.dropRoleWhitelist(role);
+    }
+
+    @Override
+    public Set<RoleResource> getRoles(RoleResource grantee, boolean includeInherited)
+    throws RequestValidationException, RequestExecutionException
+    {
+        return wrappedRoleManager.getRoles(grantee, includeInherited);
+    }
+
+    @Override
+    public Set<RoleResource> getAllRoles() throws RequestValidationException, RequestExecutionException
+    {
+        return wrappedRoleManager.getAllRoles();
+    }
+
+    @Override
+    public boolean isSuper(RoleResource role)
+    {
+        return wrappedRoleManager.isSuper(role);
+    }
+
+    @Override
+    public boolean canLogin(RoleResource role)
+    {
+        return wrappedRoleManager.canLogin(role);
+    }
+
+    @Override
+    public boolean isExistingRole(RoleResource role)
+    {
+        return wrappedRoleManager.isExistingRole(role);
     }
 }

--- a/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditWhitelistManager.java
+++ b/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditWhitelistManager.java
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import com.ericsson.bss.cassandra.ecaudit.facade.CassandraAuditException;
 import org.apache.cassandra.auth.AuthenticatedUser;
 import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.Permission;
@@ -54,6 +53,11 @@ class AuditWhitelistManager
         this.whitelistDataAccess = whitelistDataAccess;
         this.whitelistOptionParser = new WhitelistOptionParser();
         this.whitelistContract = new WhitelistContract();
+    }
+
+    public void setup()
+    {
+        whitelistDataAccess.setup();
     }
 
     void createRoleOption(RoleOptions options)

--- a/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestAuditRoleManager.java
+++ b/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestAuditRoleManager.java
@@ -86,11 +86,31 @@ public class TestAuditRoleManager
     }
 
     @Test
+    public void testStandAloneSupportedOptions()
+    {
+        AuditRoleManager standAloneAuditRoleManager = new AuditRoleManager(mockWrappedRoleManager, mockAuditWhitelistManager, false);
+
+        Set<IRoleManager.Option> options = standAloneAuditRoleManager.supportedOptions();
+
+        assertThat(options).containsExactlyElementsOf(ImmutableSet.of(IRoleManager.Option.LOGIN, IRoleManager.Option.SUPERUSER));
+    }
+
+    @Test
     public void testAlterableOptions()
     {
         Set<IRoleManager.Option> options = auditRoleManager.alterableOptions();
 
         assertThat(options).containsExactlyElementsOf(ImmutableSet.of(IRoleManager.Option.PASSWORD));
+    }
+
+    @Test
+    public void testStandAloneAlterableOptions()
+    {
+        AuditRoleManager standAloneAuditRoleManager = new AuditRoleManager(mockWrappedRoleManager, mockAuditWhitelistManager, false);
+
+        Set<IRoleManager.Option> options = standAloneAuditRoleManager.alterableOptions();
+
+        assertThat(options).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestAuditRoleManager.java
+++ b/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestAuditRoleManager.java
@@ -1,0 +1,280 @@
+package com.ericsson.bss.cassandra.ecaudit.auth;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.auth.AuthenticatedUser;
+import org.apache.cassandra.auth.DataResource;
+import org.apache.cassandra.auth.IResource;
+import org.apache.cassandra.auth.IRoleManager;
+import org.apache.cassandra.auth.RoleOptions;
+import org.apache.cassandra.auth.RoleResource;
+import org.apache.cassandra.config.Config;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class TestAuditRoleManager
+{
+    private AuditRoleManager auditRoleManager;
+
+    @Mock
+    private IRoleManager mockWrappedRoleManager;
+
+    @Mock
+    private AuditWhitelistManager mockAuditWhitelistManager;
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        Config.setClientMode(true);
+    }
+
+    @Before
+    public void before()
+    {
+        auditRoleManager = new AuditRoleManager(mockWrappedRoleManager, mockAuditWhitelistManager, true);
+    }
+
+    @After
+    public void after()
+    {
+        verifyNoMoreInteractions(mockWrappedRoleManager);
+        verifyNoMoreInteractions(mockAuditWhitelistManager);
+    }
+
+    @AfterClass
+    public static void afterClass()
+    {
+        Config.setClientMode(false);
+    }
+
+    @Test
+    public void testSetupDelegation()
+    {
+        auditRoleManager.setup();
+
+        verify(mockWrappedRoleManager).setup();
+        verify(mockAuditWhitelistManager).setup();
+    }
+
+    @Test
+    public void testSupportedOptions()
+    {
+        Set<IRoleManager.Option> options = auditRoleManager.supportedOptions();
+
+        assertThat(options).containsExactlyElementsOf(ImmutableSet.of(IRoleManager.Option.LOGIN, IRoleManager.Option.SUPERUSER, IRoleManager.Option.PASSWORD, IRoleManager.Option.OPTIONS));
+    }
+
+    @Test
+    public void testAlterableOptions()
+    {
+        Set<IRoleManager.Option> options = auditRoleManager.alterableOptions();
+
+        assertThat(options).containsExactlyElementsOf(ImmutableSet.of(IRoleManager.Option.PASSWORD));
+    }
+
+    @Test
+    public void testCreateRole()
+    {
+        AuthenticatedUser authenticatedUser = mock(AuthenticatedUser.class);
+        RoleResource role = mock(RoleResource.class);
+        RoleOptions roleOptions = mock(RoleOptions.class);
+
+        auditRoleManager.createRole(authenticatedUser, role, roleOptions);
+
+        verify(mockAuditWhitelistManager).createRoleOption(eq(roleOptions));
+        verify(mockWrappedRoleManager).createRole(eq(authenticatedUser), eq(role), eq(roleOptions));
+    }
+
+    @Test
+    public void testAlterRole()
+    {
+        AuthenticatedUser authenticatedUser = mock(AuthenticatedUser.class);
+        RoleResource role = mock(RoleResource.class);
+        RoleOptions roleOptions = mock(RoleOptions.class);
+        when(roleOptions.getPassword()).thenReturn(Optional.absent());
+        when(roleOptions.getLogin()).thenReturn(Optional.absent());
+        when(roleOptions.getSuperuser()).thenReturn(Optional.absent());
+
+        auditRoleManager.alterRole(authenticatedUser, role, roleOptions);
+
+        verify(mockAuditWhitelistManager).alterRoleOption(eq(authenticatedUser), eq(role), eq(roleOptions));
+        verify(mockWrappedRoleManager).alterRole(eq(authenticatedUser), eq(role), eq(roleOptions));
+    }
+
+    @Test
+    public void testGrantRole()
+    {
+        AuthenticatedUser authenticatedUser = mock(AuthenticatedUser.class);
+        RoleResource role = mock(RoleResource.class);
+        RoleResource grantee = mock(RoleResource.class);
+
+        auditRoleManager.grantRole(authenticatedUser, role, grantee);
+
+        verify(mockWrappedRoleManager).grantRole(eq(authenticatedUser), eq(role), eq(grantee));
+    }
+
+    @Test
+    public void testRevokeRole()
+    {
+        AuthenticatedUser authenticatedUser = mock(AuthenticatedUser.class);
+        RoleResource role = mock(RoleResource.class);
+        RoleResource grantee = mock(RoleResource.class);
+
+        auditRoleManager.revokeRole(authenticatedUser, role, grantee);
+
+        verify(mockWrappedRoleManager).revokeRole(eq(authenticatedUser), eq(role), eq(grantee));
+    }
+
+    @Test
+    public void testDropRole()
+    {
+        AuthenticatedUser authenticatedUser = mock(AuthenticatedUser.class);
+        RoleResource role = mock(RoleResource.class);
+
+        auditRoleManager.dropRole(authenticatedUser, role);
+
+        verify(mockWrappedRoleManager).dropRole(eq(authenticatedUser), eq(role));
+        verify(mockAuditWhitelistManager).dropRoleWhitelist(eq(role));
+    }
+
+    @Test
+    public void testGetRoles()
+    {
+        RoleResource role = mock(RoleResource.class);
+        Set<RoleResource> expectedRoles = givenRoleManagerHasRoleWithRoles(mockWrappedRoleManager, role);
+
+        Set<RoleResource> actualRoles = auditRoleManager.getRoles(role, true);
+
+        verify(mockWrappedRoleManager).getRoles(eq(role), eq(true));
+        assertThat(actualRoles).containsExactlyInAnyOrderElementsOf(expectedRoles);
+    }
+
+    @Test
+    public void testGetAllRoles()
+    {
+        RoleResource role = mock(RoleResource.class);
+        Set<RoleResource> expectedRoles = givenRoleManagerHasRoleWithRoles(mockWrappedRoleManager, role);
+
+        Set<RoleResource> actualRoles = auditRoleManager.getAllRoles();
+
+        verify(mockWrappedRoleManager).getAllRoles();
+        assertThat(actualRoles).containsExactlyInAnyOrderElementsOf(expectedRoles);
+    }
+
+    @Test
+    public void testIsSuper()
+    {
+        RoleResource role = mock(RoleResource.class);
+        when(mockWrappedRoleManager.isSuper(eq(role))).thenReturn(true);
+
+        boolean isSuper = auditRoleManager.isSuper(role);
+
+        verify(mockWrappedRoleManager).isSuper(eq(role));
+        assertThat(isSuper).isTrue();
+    }
+
+    @Test
+    public void testCanLogin()
+    {
+        RoleResource role = mock(RoleResource.class);
+        when(mockWrappedRoleManager.canLogin(eq(role))).thenReturn(true);
+
+        boolean canLogin = auditRoleManager.canLogin(role);
+
+        verify(mockWrappedRoleManager).canLogin(eq(role));
+        assertThat(canLogin).isTrue();
+    }
+
+    @Test
+    public void testGetCustomOptions()
+    {
+        RoleResource role = mock(RoleResource.class);
+        Map<String, String> expectedOptions = givenWhitelistManagerHasRoleWithOptions(mockAuditWhitelistManager, role);
+
+        Map<String, String> actualOptions = auditRoleManager.getCustomOptions(role);
+
+        verify(mockAuditWhitelistManager).getRoleWhitelist(eq(role));
+        assertThat(actualOptions.entrySet()).containsExactlyInAnyOrderElementsOf(expectedOptions.entrySet());
+    }
+
+    @Test
+    public void testIsExistingRole()
+    {
+        RoleResource role = mock(RoleResource.class);
+        when(mockWrappedRoleManager.isExistingRole(eq(role))).thenReturn(true);
+
+        boolean isExitingRole = auditRoleManager.isExistingRole(role);
+
+        verify(mockWrappedRoleManager).isExistingRole(eq(role));
+        assertThat(isExitingRole).isTrue();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testProtectedResources()
+    {
+        Set<IResource> cassandraResources = givenProtectedCassandraResources(mockWrappedRoleManager);
+
+        Set<IResource> actualResources = (Set<IResource>) auditRoleManager.protectedResources();
+
+        assertThat(actualResources).containsAll(cassandraResources);
+        assertThat(actualResources).containsAll(ImmutableSet.of(DataResource.table("system_auth", "role_audit_whitelists"),
+                                                                DataResource.table("system_auth", "role_audit_whitelists_v2")));
+        assertThat(actualResources).hasSize(cassandraResources.size() + 2);
+    }
+
+    @Test
+    public void testValidateConfiguration()
+    {
+        auditRoleManager.validateConfiguration();
+
+        verify(mockWrappedRoleManager).validateConfiguration();
+    }
+
+    private Set<RoleResource> givenRoleManagerHasRoleWithRoles(IRoleManager roleManager, RoleResource role)
+    {
+        RoleResource otherRole = mock(RoleResource.class);
+
+        Set<RoleResource> expectedRoles = ImmutableSet.of(role, otherRole);
+        when(roleManager.getRoles(eq(role), anyBoolean())).thenReturn(expectedRoles);
+        when(roleManager.getAllRoles()).thenReturn(expectedRoles);
+
+        return expectedRoles;
+    }
+
+    private Map<String, String> givenWhitelistManagerHasRoleWithOptions(AuditWhitelistManager auditWhitelistManager, RoleResource role)
+    {
+        Map<String, String> expectedOptions = ImmutableMap.of("optionKey", "optionValue");
+        when(auditWhitelistManager.getRoleWhitelist(eq(role))).thenReturn(expectedOptions);
+
+        return expectedOptions;
+    }
+
+    private Set<IResource> givenProtectedCassandraResources(IRoleManager roleManager)
+    {
+        Set<IResource> cassandraResources = ImmutableSet.of(DataResource.table("ks", "tbl"));
+        doReturn(cassandraResources).when(roleManager).protectedResources();
+        return cassandraResources;
+    }
+}

--- a/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestAuditWhitelistManager.java
+++ b/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestAuditWhitelistManager.java
@@ -90,6 +90,13 @@ public class TestAuditWhitelistManager
         Config.setClientMode(false);
     }
 
+    @Test
+    public void testSetupDelegation()
+    {
+        whitelistManager.setup();
+        verify(mockWhitelistDataAccess, times(1)).setup();
+    }
+
     @Test(expected = InvalidRequestException.class)
     public void testWhitelistAtCreateIsRejected()
     {


### PR DESCRIPTION
Make AuditRoleManager a decorator of CassandraRoleManager instead of extending it.
This make ARM more testable without bringing in all the runtime dependencies of CRM.
Also make audit whitelist tables a protected resource to prevent manual tampering.