### PR TITLE
Add timestamp field to custom log format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## Version 2.1.0
+* Add support for system timestamp in log message - #27
 * Fix typo of java property for custom audit.yaml path - #59
 * Build with Cassandra 3.11.4 (only flavor ecaudit_c3.11)
 * Build with Cassandra 3.0.18 (only flavor ecaudit_c3.0)

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -85,24 +85,38 @@ The ecAudit configuration file allow you to define a custom log format and manag
 
 ## Custom Log Message Format
 
-It is possible to configure a parameterized log message by providing a formatting string.
-The following parameters are available:
+To configure a custom log message format the following parameters can be configured in the ```audit.yaml``` file:
 
-| Parameter   | Field Value                                                       | Mandatory Field |
+| Parameter   | Description                                                       | Default |
+| ----------- | ----------------------------------------------------------------- | --------------- |
+| logFormat   | Parameterized log message formatting string, see examples below  | the "legacy" format, see [README](../README.md) |
+| timeFormat  | time formatter pattern, see examples below or [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns) | number of millis since EPOCH |
+| timeZone    | the time zone id, see examples below or [ZoneId](https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html#of-java.lang.String-) | system default |
+
+It is possible to configure a parameterized log message by providing a formatting string.
+The following fields are available:
+
+| Field       | Field Value                                                       | Mandatory Field |
 | ----------- | ----------------------------------------------------------------- | --------------- |
 | CLIENT      | Client IP address                                                 | yes             |
 | USER        | Username of the authenticated user                                | yes             |
 | BATCH_ID    | Internal identifier shared by all statements in a batch operation | no              |
 | STATUS      | Value is either ATTEMPT or FAILED                                 | yes             |
 | OPERATION   | The CQL statement or a textual description of the operation       | yes             |
+| TIMESTAMP   | The system timestamp of the request (\*) (**)                     | yes             |
 
+(*) - This timestamp is more accurate than the LOGBack time (since that is written asynchronously).
+If this timestamp is used, than the LOGBack timestamp can be removed by reconfiguring the encoder pattern in logback.xml.
+
+(**) - It is possible to configure a custom display format.
 
 Modify the ```audit.yaml``` configuration file.
-Parameter name goes between ```${``` and ```}``` (*bash*-style parameter substitution).
+Field name goes between ```${``` and ```}``` (*bash*-style parameter substitution).
 Use the example below as a template to define the log message format.
 
 ```YAML
-logFormat: "client=${CLIENT}, user=${USER}, status=${STATUS}, operation='${OPERATION}'"
+slf4j:
+  logFormat: "client=${CLIENT}, user=${USER}, status=${STATUS}, operation='${OPERATION}'"
 ```
 
 Which will generate logs entries like this:
@@ -111,22 +125,25 @@ Which will generate logs entries like this:
 15:18:14.089 - client=127.0.0.1, user=cassandra, status=ATTEMPT, operation='SELECT * FROM students'
 ```
 
-*Conditional formatting* of parameters is also available, which makes it possible to only log the parameter value and
+*Conditional formatting* of fields is also available, which makes it possible to only log the field value and
 its descriptive text only if a value exists, which can be useful for optional fields like BATCH_ID.
-Conditional parameters and its associated text goes between ```{?``` and ```?}```.
+Conditional fields and its associated text goes between ```{?``` and ```?}```.
 The example below use conditional formatting for the batch id to get different log messges depending on if the operation
-was part of a batch or not.
+was part of a batch or not. Also the TIMESTAMP field have a custom time format configured.
 
 ```YAML
-logFormat: "client=${CLIENT}, user=${USER}, status=${STATUS}, {?batch-id=${BATCH_ID}, ?}operation='${OPERATION}'"
+slf4j:
+  logFormat: "${TIMESTAMP}-> client=${CLIENT}, user=${USER}, status=${STATUS}, {?batch-id=${BATCH_ID}, ?}operation='${OPERATION}'"
+  timeFormat: "yyyy-MM-dd HH:mm:ss.SSS"
+  timeZone: "UTC"
 ```
 
-Which will generate logs entries like this:
+Which will generate logs entries like this (assuming LOGBack pattern does not contain timestamp as well):
 
 ```
-15:18:14.089 - client=127.0.0.1, user=cassandra, status=ATTEMPT, operation='SELECT * FROM students'
-15:18:14.090 - client=127.0.0.1, user=cassandra, status=ATTEMPT, batch-id=6f3cae9b-f1f1-4a4c-baa2-ed168ee79f9d, operation='INSERT INTO ecks.ectbl (partk, clustk, value) VALUES (?, ?, ?)[1, '1', 'valid']'
-15:18:14.091 - client=127.0.0.1, user=cassandra, status=ATTEMPT, batch-id=6f3cae9b-f1f1-4a4c-baa2-ed168ee79f9d, operation='INSERT INTO ecks.ectbl (partk, clustk, value) VALUES (?, ?, ?)[2, '2', 'valid']'
+2019-02-28 15:18:14.089-> client=127.0.0.1, user=cassandra, status=ATTEMPT, operation='SELECT * FROM students'
+2019-02-28 15:18:14.090-> client=127.0.0.1, user=cassandra, status=ATTEMPT, batch-id=6f3cae9b-f1f1-4a4c-baa2-ed168ee79f9d, operation='INSERT INTO ecks.ectbl (partk, clustk, value) VALUES (?, ?, ?)[1, '1', 'valid']'
+2019-02-28 15:18:14.091-> client=127.0.0.1, user=cassandra, status=ATTEMPT, batch-id=6f3cae9b-f1f1-4a4c-baa2-ed168ee79f9d, operation='INSERT INTO ecks.ectbl (partk, clustk, value) VALUES (?, ?, ?)[2, '2', 'valid']'
 ```
 
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -106,7 +106,7 @@ The following fields are available:
 | TIMESTAMP   | The system timestamp of the request (\*) (**)                     | yes             |
 
 (*) - This timestamp is more accurate than the LOGBack time (since that is written asynchronously).
-If this timestamp is used, than the LOGBack timestamp can be removed by reconfiguring the encoder pattern in logback.xml.
+If this timestamp is used, then the LOGBack timestamp can be removed by reconfiguring the encoder pattern in logback.xml.
 
 (**) - It is possible to configure a custom display format.
 

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/AuditAdapter.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/AuditAdapter.java
@@ -56,10 +56,8 @@ public class AuditAdapter
     /**
      * Constructor, see {@link AuditAdapterFactory#createAuditAdapter()}
      *
-     * @param auditor
-     *            the auditor to use
-     * @param entryBuilderFactory
-     *            the audit entry builder factory to use
+     * @param auditor             the auditor to use
+     * @param entryBuilderFactory the audit entry builder factory to use
      */
     AuditAdapter(Auditor auditor, AuditEntryBuilderFactory entryBuilderFactory)
     {
@@ -85,21 +83,20 @@ public class AuditAdapter
     /**
      * Audit a regular CQL statement.
      *
-     * @param operation
-     *            the CQL statement to audit
-     * @param state
-     *            the client state accompanying the statement
-     * @param status
-     *            the statement operation status
+     * @param operation the CQL statement to audit
+     * @param state     the client state accompanying the statement
+     * @param status    the statement operation status
+     * @param timestamp the system timestamp for the request
      */
-    public void auditRegular(String operation, ClientState state, Status status)
+    public void auditRegular(String operation, ClientState state, Status status, long timestamp)
     {
         AuditEntry logEntry = entryBuilderFactory.createEntryBuilder(operation, state)
-                .client(state.getRemoteAddress().getAddress())
-                .user(state.getUser().getName())
-                .operation(new SimpleAuditOperation(operation))
-                .status(status)
-                .build();
+                                                 .client(state.getRemoteAddress().getAddress())
+                                                 .user(state.getUser().getName())
+                                                 .operation(new SimpleAuditOperation(operation))
+                                                 .status(status)
+                                                 .timestamp(timestamp)
+                                                 .build();
 
         auditor.audit(logEntry);
     }
@@ -107,25 +104,22 @@ public class AuditAdapter
     /**
      * Audit a prepared statement.
      *
-     * @param id
-     *            the statement id
-     * @param statement
-     *            the statement to audit
-     * @param state
-     *            the client state accompanying the statement
-     * @param options
-     *            the options accompanying the statement
-     * @param status
-     *            the statement operation status
+     * @param id        the statement id
+     * @param statement the statement to audit
+     * @param state     the client state accompanying the statement
+     * @param options   the options accompanying the statement
+     * @param status    the status of the operation
+     * @param timestamp the system timestamp for the request
      */
-    public void auditPrepared(MD5Digest id, CQLStatement statement, ClientState state, QueryOptions options, Status status)
+    public void auditPrepared(MD5Digest id, CQLStatement statement, ClientState state, QueryOptions options, Status status, long timestamp)
     {
         AuditEntry logEntry = entryBuilderFactory.createEntryBuilder(statement)
-                .client(state.getRemoteAddress().getAddress())
-                .user(state.getUser().getName())
-                .operation(new PreparedAuditOperation(idQueryCache.get(id), options))
-                .status(status)
-                .build();
+                                                 .client(state.getRemoteAddress().getAddress())
+                                                 .user(state.getUser().getName())
+                                                 .operation(new PreparedAuditOperation(idQueryCache.get(id), options))
+                                                 .status(status)
+                                                 .timestamp(timestamp)
+                                                 .build();
 
         auditor.audit(logEntry);
     }
@@ -133,24 +127,21 @@ public class AuditAdapter
     /**
      * Audit a batch statement.
      *
-     * @param statement
-     *            the batch statement to audit
-     * @param uuid
-     *            to identify the batch
-     * @param state
-     *            the client state accompanying the statement
-     * @param options
-     *            the batch options accompanying the statement
-     * @param status
-     *            the status of the operation
+     * @param statement the batch statement to audit
+     * @param uuid      to identify the batch
+     * @param state     the client state accompanying the statement
+     * @param options   the batch options accompanying the statement
+     * @param status    the status of the operation
+     * @param timestamp the system timestamp for the request
      */
-    public void auditBatch(BatchStatement statement, UUID uuid, ClientState state, BatchQueryOptions options, Status status)
+    public void auditBatch(BatchStatement statement, UUID uuid, ClientState state, BatchQueryOptions options, Status status, long timestamp)
     {
         AuditEntry.Builder builder = entryBuilderFactory.createBatchEntryBuilder()
-                .client(state.getRemoteAddress().getAddress())
-                .user(state.getUser().getName())
-                .batch(uuid)
-                .status(status);
+                                                        .client(state.getRemoteAddress().getAddress())
+                                                        .user(state.getUser().getName())
+                                                        .batch(uuid)
+                                                        .status(status)
+                                                        .timestamp(timestamp);
 
         if (status == Status.FAILED)
         {
@@ -169,21 +160,20 @@ public class AuditAdapter
     /**
      * Audit an authentication attempt.
      *
-     * @param username
-     *            the user to authenticate
-     * @param clientIp
-     *            the address of the client that tries to authenticate
-     * @param status
-     *            the status of the operation
+     * @param username the user to authenticate
+     * @param clientIp the address of the client that tries to authenticate
+     * @param status   the status of the operation
+     * @param timestamp the system timestamp for the request
      */
-    public void auditAuth(String username, InetAddress clientIp, Status status)
+    public void auditAuth(String username, InetAddress clientIp, Status status, long timestamp)
     {
         AuditEntry logEntry = entryBuilderFactory.createAuthenticationEntryBuilder()
-                .client(clientIp)
-                .user(username)
-                .status(status)
-                .operation(status == Status.ATTEMPT ? AUTHENTICATION_ATTEMPT : AUTHENTICATION_FAILED)
-                .build();
+                                                 .client(clientIp)
+                                                 .user(username)
+                                                 .status(status)
+                                                 .operation(status == Status.ATTEMPT ? AUTHENTICATION_ATTEMPT : AUTHENTICATION_FAILED)
+                                                 .timestamp(timestamp)
+                                                 .build();
 
         auditor.audit(logEntry);
     }
@@ -191,10 +181,8 @@ public class AuditAdapter
     /**
      * Map a prepared statement id to a raw query string.
      *
-     * @param id
-     *            the id of the prepared statement
-     * @param query
-     *            the query string
+     * @param id    the id of the prepared statement
+     * @param query the query string
      */
     public void mapIdToQuery(MD5Digest id, String query)
     {
@@ -204,14 +192,10 @@ public class AuditAdapter
     /**
      * Get all the audit entries for a batch
      *
-     * @param builder
-     *            the prepared audit entry builder
-     * @param batchStatement
-     *            the batch statement
-     * @param state
-     *            the client state accompanying the statement
-     * @param options
-     *            the options to get the operations from
+     * @param builder        the prepared audit entry builder
+     * @param batchStatement the batch statement
+     * @param state          the client state accompanying the statement
+     * @param options        the options to get the operations from
      * @return a collection of operations, as strings
      */
     private Collection<AuditEntry> getBatchOperations(AuditEntry.Builder builder, BatchStatement batchStatement, ClientState state, BatchQueryOptions options)
@@ -221,7 +205,7 @@ public class AuditAdapter
         int statementIndex = 0;
         for (Object queryOrId : options.getQueryOrIdList())
         {
-            if(queryOrId instanceof MD5Digest)
+            if (queryOrId instanceof MD5Digest)
             {
                 builder = entryBuilderFactory.updateBatchEntryBuilder(builder, batchStatement.getStatements().get(statementIndex));
                 builder = builder.operation(new PreparedAuditOperation(idQueryCache.get(queryOrId), options.forStatement(statementIndex)));

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditPasswordAuthenticator.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditPasswordAuthenticator.java
@@ -129,14 +129,15 @@ public class AuditPasswordAuthenticator implements IAuthenticator
         @Override
         public AuthenticatedUser getAuthenticatedUser() throws AuthenticationException
         {
-            auditAdapter.auditAuth(decodedUsername, clientAddress, Status.ATTEMPT);
+            long timestamp = System.currentTimeMillis();
+            auditAdapter.auditAuth(decodedUsername, clientAddress, Status.ATTEMPT, timestamp);
             try
             {
                 return saslNegotiator.getAuthenticatedUser();
             }
             catch (RuntimeException e)
             {
-                auditAdapter.auditAuth(decodedUsername, clientAddress, Status.FAILED);
+                auditAdapter.auditAuth(decodedUsername, clientAddress, Status.FAILED, timestamp);
                 throw e;
             }
         }

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/config/AuditConfig.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/config/AuditConfig.java
@@ -49,7 +49,7 @@ public class AuditConfig
         private static final AuditConfig INSTANCE = new AuditConfig(AuditYamlConfigurationLoader.withSystemProperties());
     }
 
-    public synchronized List<String> getYamlWhitelist() throws ConfigurationException
+    public List<String> getYamlWhitelist() throws ConfigurationException
     {
         loadConfigIfNeeded();
 
@@ -61,7 +61,7 @@ public class AuditConfig
         return yamlConfig.getWhitelist();
     }
 
-    public synchronized String getLogFormat() throws ConfigurationException
+    public String getLogFormat() throws ConfigurationException
     {
         loadConfigIfNeeded();
 
@@ -70,7 +70,7 @@ public class AuditConfig
                        .orElse(DEFAULT_FORMAT);
     }
 
-    public synchronized Optional<DateTimeFormatter> getTimeFormatter() throws ConfigurationException
+    public Optional<DateTimeFormatter> getTimeFormatter() throws ConfigurationException
     {
         loadConfigIfNeeded();
         try
@@ -102,7 +102,7 @@ public class AuditConfig
                     .map(formatter -> formatter.withZone(timeZoneId));
     }
 
-    private void loadConfigIfNeeded()
+    private synchronized void loadConfigIfNeeded()
     {
         if (yamlConfig == null)
         {

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/config/AuditConfig.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/config/AuditConfig.java
@@ -15,7 +15,12 @@
  */
 package com.ericsson.bss.cassandra.ecaudit.config;
 
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.zone.ZoneRulesException;
 import java.util.List;
+import java.util.Optional;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -23,6 +28,8 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 
 public class AuditConfig
 {
+    private static final String DEFAULT_FORMAT = "client:'${CLIENT}'|user:'${USER}'{?|batchId:'${BATCH_ID}'?}|status:'${STATUS}'|operation:'${OPERATION}'";
+
     private final AuditYamlConfigurationLoader yamlConfigurationLoader;
     private AuditYamlConfig yamlConfig;
 
@@ -44,10 +51,7 @@ public class AuditConfig
 
     public synchronized List<String> getYamlWhitelist() throws ConfigurationException
     {
-        if (yamlConfig == null)
-        {
-            yamlConfig = yamlConfigurationLoader.loadConfig();
-        }
+        loadConfigIfNeeded();
 
         if (!yamlConfig.isFromFile())
         {
@@ -59,11 +63,50 @@ public class AuditConfig
 
     public synchronized String getLogFormat() throws ConfigurationException
     {
+        loadConfigIfNeeded();
+
+        return Optional.ofNullable(yamlConfig.getSlf4j())
+                       .map(AuditYamlSlf4jConfig::getLogFormat)
+                       .orElse(DEFAULT_FORMAT);
+    }
+
+    public synchronized Optional<DateTimeFormatter> getTimeFormatter() throws ConfigurationException
+    {
+        loadConfigIfNeeded();
+        try
+        {
+            Optional<DateTimeFormatter> timeFormatter = getFormatter();
+            return timeFormatter;
+        }
+        catch (IllegalArgumentException e)
+        {
+            throw new ConfigurationException("Invalid time format configuration.", e);
+        }
+        catch (DateTimeException e)
+        {
+            throw new ConfigurationException("Invalid time zone configuration.", e);
+        }
+
+    }
+
+    private Optional<DateTimeFormatter> getFormatter()
+    {
+        Optional<AuditYamlSlf4jConfig> slf4j = Optional.ofNullable(yamlConfig.getSlf4j());
+
+        ZoneId timeZoneId = slf4j.map(AuditYamlSlf4jConfig::getTimeZone)
+                                 .map(ZoneId::of)
+                                 .orElse(ZoneId.systemDefault());
+
+        return slf4j.map(AuditYamlSlf4jConfig::getTimeFormat)
+                    .map(DateTimeFormatter::ofPattern)
+                    .map(formatter -> formatter.withZone(timeZoneId));
+    }
+
+    private void loadConfigIfNeeded()
+    {
         if (yamlConfig == null)
         {
             yamlConfig = yamlConfigurationLoader.loadConfig();
         }
-
-        return yamlConfig.getLogFormat();
     }
 }

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/config/AuditYamlConfig.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/config/AuditYamlConfig.java
@@ -23,11 +23,9 @@ import java.util.List;
  */
 public final class AuditYamlConfig
 {
-    private static final String DEFAULT_FORMAT = "client:'${CLIENT}'|user:'${USER}'{?|batchId:'${BATCH_ID}'?}|status:'${STATUS}'|operation:'${OPERATION}'";
-
     private boolean fromFile = true;
     private List<String> whitelist;
-    private String logFormat;
+    private AuditYamlSlf4jConfig slf4j;
 
     static AuditYamlConfig createWithoutFile()
     {
@@ -62,20 +60,15 @@ public final class AuditYamlConfig
     }
 
     /**
-     * @return the log format in this configuration
+     * @return the SLF4J configuration or {@code null} if not configured.
      */
-    public String getLogFormat()
+    public AuditYamlSlf4jConfig getSlf4j()
     {
-        return logFormat != null ? logFormat : DEFAULT_FORMAT;
+        return slf4j;
     }
 
-    /**
-     * Set the log format in this configuration
-     *
-     * @param logFormat the log format string
-     */
-    public void setLogFormat(String logFormat)
+    public void setSlf4j(AuditYamlSlf4jConfig slf4j)
     {
-        this.logFormat = logFormat;
+        this.slf4j = slf4j;
     }
 }

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/config/AuditYamlSlf4jConfig.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/config/AuditYamlSlf4jConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.config;
+
+/**
+ * Data class for SLF4J configuration
+ */
+public final class AuditYamlSlf4jConfig
+{
+    private String logFormat;
+    private String timeFormat;
+    private String timeZone;
+
+    /**
+     * @return the log format in this configuration
+     */
+    public String getLogFormat()
+    {
+        return logFormat;
+    }
+
+    /**
+     * Set the log format in this configuration
+     *
+     * @param logFormat the log format string
+     */
+    public void setLogFormat(String logFormat)
+    {
+        this.logFormat = logFormat;
+    }
+
+    /**
+     * @return the time format in this configuration
+     */
+    public String getTimeFormat()
+    {
+        return timeFormat;
+    }
+
+    /**
+     * Set the time format in this configuration
+     *
+     * @param timeFormat the time format string
+     */
+    public void setTimeFormat(String timeFormat)
+    {
+        this.timeFormat = timeFormat;
+    }
+
+    /**
+     * @return the time zone in this configuration
+     */
+    public String getTimeZone()
+    {
+        return timeZone;
+    }
+
+    /**
+     * Set the time zone in this configuration
+     *
+     * @param timeZone the time zone string
+     */
+    public void setTimeZone(String timeZone)
+    {
+        this.timeZone = timeZone;
+    }
+}

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/AuditEntry.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/AuditEntry.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.Permission;
 
@@ -37,6 +39,7 @@ public class AuditEntry
     private final String user;
     private final UUID batchId;
     private final Status status;
+    private final long timestamp;
 
     /**
      * @see #newBuilder()
@@ -50,6 +53,7 @@ public class AuditEntry
         this.user = builder.user;
         this.batchId = builder.batchId;
         this.status = builder.status;
+        this.timestamp = builder.timestamp;
     }
 
     public InetAddress getClientAddress()
@@ -108,13 +112,21 @@ public class AuditEntry
     }
 
     /**
+     * @return the timestamp when this entry was created. Represented by the number of milliseconds since Epoch.
+     */
+    public long getTimestamp()
+    {
+        return timestamp;
+    }
+
+    /**
      * Create a new {@link Builder} instance.
      *
      * @return a new instance of {@link Builder}.
      */
     public static AuditEntry.Builder newBuilder()
     {
-        return new Builder();
+        return new Builder(System.currentTimeMillis());
     }
 
     /**
@@ -129,6 +141,13 @@ public class AuditEntry
         private String user;
         private UUID batchId;
         private Status status;
+        private long timestamp;
+
+        @VisibleForTesting
+        Builder(long timestamp)
+        {
+            this.timestamp = timestamp;
+        }
 
         public Builder client(InetAddress address)
         {
@@ -211,6 +230,7 @@ public class AuditEntry
             this.user = entry.getUser();
             this.batchId = entry.getBatchId().orElse(null);
             this.status = entry.getStatus();
+            this.timestamp = entry.getTimestamp();
             return this;
         }
 

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/AuditEntry.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/AuditEntry.java
@@ -39,7 +39,7 @@ public class AuditEntry
     private final String user;
     private final UUID batchId;
     private final Status status;
-    private final long timestamp;
+    private final Long timestamp;
 
     /**
      * @see #newBuilder()
@@ -114,7 +114,7 @@ public class AuditEntry
     /**
      * @return the timestamp when this entry was created. Represented by the number of milliseconds since Epoch.
      */
-    public long getTimestamp()
+    public Long getTimestamp()
     {
         return timestamp;
     }
@@ -126,7 +126,7 @@ public class AuditEntry
      */
     public static AuditEntry.Builder newBuilder()
     {
-        return new Builder(System.currentTimeMillis());
+        return new Builder();
     }
 
     /**
@@ -141,13 +141,7 @@ public class AuditEntry
         private String user;
         private UUID batchId;
         private Status status;
-        private long timestamp;
-
-        @VisibleForTesting
-        Builder(long timestamp)
-        {
-            this.timestamp = timestamp;
-        }
+        private Long timestamp;
 
         public Builder client(InetAddress address)
         {
@@ -212,6 +206,12 @@ public class AuditEntry
         public Builder status(Status status)
         {
             this.status = status;
+            return this;
+        }
+
+        public Builder timestamp(Long timestamp)
+        {
+            this.timestamp = timestamp;
             return this;
         }
 

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/logger/Slf4jAuditLogger.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/logger/Slf4jAuditLogger.java
@@ -15,8 +15,11 @@
  */
 package com.ericsson.bss.cassandra.ecaudit.logger;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -36,13 +39,13 @@ import static java.util.stream.Collectors.toList;
  * Implements an {@link AuditLogger} that writes {@link AuditEntry} instance into file using {@link Logger}.
  * <br>
  * It is possible to configure a parameterized log message by providing a formatting string {@link AuditConfig#getLogFormat()}.
- * The format for a parameter is {@code ${<Parameter Name>}}. With a formatting string like this: {@code "${USER} executed '${OPERATION}' from ${CLIENT}"},
+ * The format for a field is {@code ${<Field Name>}}. With a formatting string like this: {@code "${USER} executed '${OPERATION}' from ${CLIENT}"},
  * the logged string could look like this:
  * <ul>
  * <li>"Duke executed 'select * from students;' from 1.2.3.4"</li>
  * </ul>
  * <p>
- * Conditional formatting of parameters is also available, which makes it possible to only log the parameter value and
+ * Conditional formatting of fields is also available, which makes it possible to only log the field value and
  * its descriptive text if a value exists. The formatting string {@code "user:${USER}, client:${CLIENT}{?, executed from batch:${BATCH_ID}?}"}
  * will log different things depending on if there is a BATCH_ID or not:
  * <ul>
@@ -54,22 +57,15 @@ public class Slf4jAuditLogger implements AuditLogger
 {
     public static final String AUDIT_LOGGER_NAME = "ECAUDIT";
 
-    private static final String PARAMETER_EXP = "\\$\\{(.*?)}"; // Non-greedy matching of parameter
-    private static final String OPTIONAL_PARAMETER_EXP = "\\{\\?(.*?)\\$\\{(.*?)}(.*?)\\?}";
-    private static final String COMBINED_PARAMETERS_EXP = PARAMETER_EXP + '|' + OPTIONAL_PARAMETER_EXP;
-    private static final Pattern PARAMETER_PATTERN = Pattern.compile(COMBINED_PARAMETERS_EXP);
+    private static final String FIELD_EXP = "\\$\\{(.*?)}"; // Non-greedy matching of field
+    private static final String OPTIONAL_FIELD_EXP = "\\{\\?(.*?)\\$\\{(.*?)}(.*?)\\?}";
+    private static final String COMBINED_FIELDS_EXP = FIELD_EXP + '|' + OPTIONAL_FIELD_EXP;
+    private static final Pattern FIELD_PATTERN = Pattern.compile(COMBINED_FIELDS_EXP);
 
-    static final ImmutableMap<String, Function<AuditEntry, Object>> AVAILABLE_PARAMETER_FUNCTIONS =
-    ImmutableMap.<String, Function<AuditEntry, Object>>builder().put("CLIENT", entry -> entry.getClientAddress().getHostAddress())
-                                                                .put("USER", AuditEntry::getUser)
-                                                                .put("BATCH_ID", entry -> entry.getBatchId().orElse(null))
-                                                                .put("STATUS", AuditEntry::getStatus)
-                                                                .put("OPERATION", entry -> entry.getOperation().getOperationString())
-                                                                .build();
-
+    private final Map<String, Function<AuditEntry, Object>> availableFieldFunctionMap;
     private final Logger auditLogger; // NOSONAR
     private final String logTemplate;
-    private final List<Function<AuditEntry, Object>> parameterFunctions;
+    private final List<Function<AuditEntry, Object>> fieldFunctions;
 
     /**
      * Constructor, injects logger from {@link LoggerFactory}.
@@ -91,46 +87,71 @@ public class Slf4jAuditLogger implements AuditLogger
     Slf4jAuditLogger(AuditConfig auditConfig, Logger logger)
     {
         auditLogger = logger;
+        availableFieldFunctionMap = getAvailableFieldFunctionMap(auditConfig);
         String logFormat = auditConfig.getLogFormat();
         logTemplate = getTemplateFromFormatString(logFormat);
-        parameterFunctions = getParameterFunctions(logFormat);
+        fieldFunctions = getFieldFunctions(logFormat);
+    }
+
+    static Map<String, Function<AuditEntry, Object>> getAvailableFieldFunctionMap(AuditConfig auditConfig)
+    {
+        return ImmutableMap.<String, Function<AuditEntry, Object>>builder()
+               .put("CLIENT", entry -> entry.getClientAddress().getHostAddress())
+               .put("USER", AuditEntry::getUser)
+               .put("BATCH_ID", entry -> entry.getBatchId().orElse(null))
+               .put("STATUS", AuditEntry::getStatus)
+               .put("OPERATION", entry -> entry.getOperation().getOperationString())
+               .put("TIMESTAMP", getTimeFunction(auditConfig))
+               .build();
+    }
+
+    static Function<AuditEntry, Object> getTimeFunction(AuditConfig auditConfig)
+    {
+        return auditConfig.getTimeFormatter()
+                          .map(Slf4jAuditLogger::getFormattedTimestamp)
+                          .orElse(AuditEntry::getTimestamp);
+    }
+
+    private static Function<AuditEntry, Object> getFormattedTimestamp(DateTimeFormatter formatter)
+    {
+        return auditEntry -> formatter.format(Instant.ofEpochMilli(auditEntry.getTimestamp()));
     }
 
     private static String getTemplateFromFormatString(String logFormat)
     {
-        return logFormat.replaceAll(OPTIONAL_PARAMETER_EXP, "{}{}{}").replaceAll(PARAMETER_EXP, "{}");
+        return logFormat.replaceAll(OPTIONAL_FIELD_EXP, "{}{}{}").replaceAll(FIELD_EXP, "{}");
     }
 
-    static List<Function<AuditEntry, Object>> getParameterFunctions(String logFormat)
+    List<Function<AuditEntry, Object>> getFieldFunctions(String logFormat)
     {
-        List<Function<AuditEntry, Object>> parameterFunctions = new ArrayList<>();
-        Matcher matcher = PARAMETER_PATTERN.matcher(logFormat);
+        List<Function<AuditEntry, Object>> fieldFunctions = new ArrayList<>();
+        Matcher matcher = FIELD_PATTERN.matcher(logFormat);
         while (matcher.find())
         {
-            String normalParameter = matcher.group(1);
-            if (normalParameter != null)
+            String normalField = matcher.group(1);
+            if (normalField != null)
             {
-                Function<AuditEntry, Object> valueSupplier = AVAILABLE_PARAMETER_FUNCTIONS.computeIfAbsent(normalParameter, throwConfigurationException());
-                parameterFunctions.add(valueSupplier);
+                Function<AuditEntry, Object> valueSupplier = availableFieldFunctionMap.computeIfAbsent(normalField, throwConfigurationException());
+                fieldFunctions.add(valueSupplier);
             }
-            else // Optional parameter
+            else // Optional field
             {
                 String descriptionLeft = matcher.group(2);
-                String innerParameter = matcher.group(3);
+                String innerField = matcher.group(3);
                 String descriptionRight = matcher.group(4);
-                Function<AuditEntry, Object> valueSupplier = AVAILABLE_PARAMETER_FUNCTIONS.computeIfAbsent(innerParameter, throwConfigurationException());
-                parameterFunctions.add(valueSupplier.andThen(getDescriptionIfValuePresent(descriptionLeft)));
-                parameterFunctions.add(valueSupplier.andThen(Slf4jAuditLogger::getValueOrEmptyString));
-                parameterFunctions.add(valueSupplier.andThen(getDescriptionIfValuePresent(descriptionRight)));
+                Function<AuditEntry, Object> valueSupplier = availableFieldFunctionMap.computeIfAbsent(innerField, throwConfigurationException());
+                fieldFunctions.add(valueSupplier.andThen(getDescriptionIfValuePresent(descriptionLeft)));
+                fieldFunctions.add(valueSupplier.andThen(Slf4jAuditLogger::getValueOrEmptyString));
+                fieldFunctions.add(valueSupplier.andThen(getDescriptionIfValuePresent(descriptionRight)));
             }
         }
-        return parameterFunctions;
+        return fieldFunctions;
     }
 
     private static Function<String, Function<AuditEntry, Object>> throwConfigurationException()
     {
         return key -> {
-            throw new ConfigurationException("Unknown log format parameter: " + key);
+            throw new ConfigurationException("Unknown log format field: " + key);
         };
     }
 
@@ -147,9 +168,9 @@ public class Slf4jAuditLogger implements AuditLogger
     @Override
     public void log(AuditEntry logEntry)
     {
-        List<ToStringer> parameters = parameterFunctions.stream()
-                                                        .map(valueSupplier -> new ToStringer<>(logEntry, valueSupplier))
-                                                        .collect(toList());
-        auditLogger.info(logTemplate, parameters.toArray());
+        List<ToStringer> fields = fieldFunctions.stream()
+                                                    .map(valueSupplier -> new ToStringer<>(logEntry, valueSupplier))
+                                                    .collect(toList());
+        auditLogger.info(logTemplate, fields.toArray());
     }
 }

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/TestAuditAdapter.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/TestAuditAdapter.java
@@ -75,6 +75,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class TestAuditAdapter
 {
+    private static final long TIMESTAMP = 42L;
     @Mock
     private AuthenticatedUser mockUser;
 
@@ -147,7 +148,7 @@ public class TestAuditAdapter
                               .permissions(ImmutableSet.of(Permission.SELECT))
                               .resource(DataResource.table("ks", "tbl")));
 
-        auditAdapter.auditRegular(expectedStatement, mockState, expectedStatus);
+        auditAdapter.auditRegular(expectedStatement, mockState, expectedStatus, TIMESTAMP);
 
         // Capture and perform validation
         ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.forClass(AuditEntry.class);
@@ -160,6 +161,7 @@ public class TestAuditAdapter
         assertThat(captured.getStatus()).isEqualByComparingTo(expectedStatus);
         assertThat(captured.getBatchId()).isEqualTo(Optional.empty());
         assertThat(captured.getResource()).isEqualTo(DataResource.table("ks", "tbl"));
+        assertThat(captured.getTimestamp()).isEqualTo(TIMESTAMP);
     }
 
     @Test
@@ -179,7 +181,7 @@ public class TestAuditAdapter
                               .permissions(ImmutableSet.of(Permission.SELECT))
                               .resource(DataResource.table("ks", "tbl")));
 
-        auditAdapter.auditRegular(expectedStatement, mockState, expectedStatus);
+        auditAdapter.auditRegular(expectedStatement, mockState, expectedStatus, TIMESTAMP);
 
         // Capture and perform validation
         ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.forClass(AuditEntry.class);
@@ -193,6 +195,7 @@ public class TestAuditAdapter
         assertThat(captured.getBatchId()).isEqualTo(Optional.empty());
         assertThat(captured.getPermissions()).isEqualTo(Sets.immutableEnumSet(Permission.SELECT));
         assertThat(captured.getResource()).isEqualTo(DataResource.table("ks", "tbl"));
+        assertThat(captured.getTimestamp()).isEqualTo(TIMESTAMP);
     }
 
     @Test
@@ -222,7 +225,7 @@ public class TestAuditAdapter
                               .resource(DataResource.table("ks", "cf")));
 
         auditAdapter.mapIdToQuery(statementId, preparedQuery);
-        auditAdapter.auditPrepared(statementId, mockStatement, mockState, mockOptions, expectedStatus);
+        auditAdapter.auditPrepared(statementId, mockStatement, mockState, mockOptions, expectedStatus, TIMESTAMP);
 
         // Capture and perform validation
         ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.forClass(AuditEntry.class);
@@ -237,6 +240,7 @@ public class TestAuditAdapter
         assertThat(captured.getBatchId()).isEqualTo(Optional.empty());
         assertThat(captured.getPermissions()).isEqualTo(Sets.immutableEnumSet(Permission.SELECT));
         assertThat(captured.getResource()).isEqualTo(DataResource.table("ks", "cf"));
+        assertThat(captured.getTimestamp()).isEqualTo(TIMESTAMP);
     }
 
     @Test
@@ -266,7 +270,7 @@ public class TestAuditAdapter
                               .resource(DataResource.table("ks", "cf")));
 
         auditAdapter.mapIdToQuery(statementId, preparedQuery);
-        auditAdapter.auditPrepared(statementId, mockStatement, mockState, mockOptions, expectedStatus);
+        auditAdapter.auditPrepared(statementId, mockStatement, mockState, mockOptions, expectedStatus, TIMESTAMP);
 
         // Capture and perform validation
         ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.forClass(AuditEntry.class);
@@ -281,6 +285,7 @@ public class TestAuditAdapter
         assertThat(captured.getBatchId()).isEqualTo(Optional.empty());
         assertThat(captured.getPermissions()).isEqualTo(Sets.immutableEnumSet(Permission.SELECT));
         assertThat(captured.getResource()).isEqualTo(DataResource.table("ks", "cf"));
+        assertThat(captured.getTimestamp()).isEqualTo(TIMESTAMP);
     }
 
     @SuppressWarnings("unchecked")
@@ -307,7 +312,7 @@ public class TestAuditAdapter
                     .permissions(Sets.immutableEnumSet(Permission.MODIFY, Permission.SELECT))
                     .resource(DataResource.root()));
 
-        auditAdapter.auditBatch(mockBatchStatement, expectedBatchId, mockState, mockBatchOptions, expectedStatus);
+        auditAdapter.auditBatch(mockBatchStatement, expectedBatchId, mockState, mockBatchOptions, expectedStatus, TIMESTAMP);
 
         ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.forClass(AuditEntry.class);
         verify(mockAuditor, times(1)).audit(captor.capture());
@@ -321,6 +326,7 @@ public class TestAuditAdapter
         assertThat(entries).extracting(AuditEntry::getOperation).extracting(AuditOperation::getOperationString).containsOnly(expectedQuery);
         assertThat(entries).extracting(AuditEntry::getPermissions).containsOnly(Sets.immutableEnumSet(Permission.MODIFY, Permission.SELECT));
         assertThat(entries).extracting(AuditEntry::getResource).containsOnly(DataResource.root());
+        assertThat(entries).extracting(AuditEntry::getTimestamp).containsOnly(TIMESTAMP);
     }
 
     @SuppressWarnings("unchecked")
@@ -350,7 +356,7 @@ public class TestAuditAdapter
         when(mockAuditEntryBuilderFactory.updateBatchEntryBuilder(any(AuditEntry.Builder.class), any(String.class), any(ClientState.class)))
         .thenAnswer(a -> a.getArgument(0));
 
-        auditAdapter.auditBatch(mockBatchStatement, expectedBatchId, mockState, mockBatchOptions, expectedStatus);
+        auditAdapter.auditBatch(mockBatchStatement, expectedBatchId, mockState, mockBatchOptions, expectedStatus, TIMESTAMP);
 
         ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.forClass(AuditEntry.class);
         verify(mockAuditor, times(3)).audit(captor.capture());
@@ -364,6 +370,7 @@ public class TestAuditAdapter
         assertThat(entries).extracting(AuditEntry::getOperation).extracting(AuditOperation::getOperationString).containsExactly("query1", "query2", "query3");
         assertThat(entries).extracting(AuditEntry::getPermissions).containsOnly(Sets.immutableEnumSet(Permission.MODIFY));
         assertThat(entries).extracting(AuditEntry::getResource).containsOnly(DataResource.root());
+        assertThat(entries).extracting(AuditEntry::getTimestamp).containsOnly(TIMESTAMP);
     }
 
     @SuppressWarnings("unchecked")
@@ -407,7 +414,7 @@ public class TestAuditAdapter
         .thenAnswer(a -> a.getArgument(0));
 
         auditAdapter.mapIdToQuery(id, preparedQuery);
-        auditAdapter.auditBatch(mockBatchStatement, expectedBatchId, mockState, mockBatchOptions, expectedStatus);
+        auditAdapter.auditBatch(mockBatchStatement, expectedBatchId, mockState, mockBatchOptions, expectedStatus, TIMESTAMP);
 
         // Begin, prepared statement, end
         ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.forClass(AuditEntry.class);
@@ -423,6 +430,7 @@ public class TestAuditAdapter
         assertThat(entries).extracting(AuditEntry::getOperation).extracting(AuditOperation::getOperationString).containsExactly(expectedQuery);
         assertThat(entries).extracting(AuditEntry::getPermissions).containsOnly(Sets.immutableEnumSet(Permission.MODIFY));
         assertThat(entries).extracting(AuditEntry::getResource).containsOnly(DataResource.root());
+        assertThat(entries).extracting(AuditEntry::getTimestamp).containsOnly(TIMESTAMP);
     }
 
     @Test
@@ -438,7 +446,7 @@ public class TestAuditAdapter
                               .permissions(ImmutableSet.of(Permission.EXECUTE))
                               .resource(ConnectionResource.root()));
 
-        auditAdapter.auditAuth(expectedUser, expectedAddress, expectedStatus);
+        auditAdapter.auditAuth(expectedUser, expectedAddress, expectedStatus, TIMESTAMP);
 
         // Capture and perform validation
         ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.forClass(AuditEntry.class);
@@ -452,6 +460,7 @@ public class TestAuditAdapter
         assertThat(captured.getBatchId()).isEqualTo(Optional.empty());
         assertThat(captured.getPermissions()).isEqualTo(Sets.immutableEnumSet(Permission.EXECUTE));
         assertThat(captured.getResource()).isEqualTo(ConnectionResource.root());
+        assertThat(captured.getTimestamp()).isEqualTo(TIMESTAMP);
     }
 
     @Test
@@ -467,7 +476,7 @@ public class TestAuditAdapter
                               .permissions(ImmutableSet.of(Permission.EXECUTE))
                               .resource(ConnectionResource.root()));
 
-        auditAdapter.auditAuth(expectedUser, expectedAddress, expectedStatus);
+        auditAdapter.auditAuth(expectedUser, expectedAddress, expectedStatus, TIMESTAMP);
 
         // Capture and perform validation
         ArgumentCaptor<AuditEntry> captor = ArgumentCaptor.forClass(AuditEntry.class);
@@ -481,6 +490,7 @@ public class TestAuditAdapter
         assertThat(captured.getBatchId()).isEqualTo(Optional.empty());
         assertThat(captured.getPermissions()).isEqualTo(Sets.immutableEnumSet(Permission.EXECUTE));
         assertThat(captured.getResource()).isEqualTo(ConnectionResource.root());
+        assertThat(captured.getTimestamp()).isEqualTo(TIMESTAMP);
     }
 
     private ImmutableList<ColumnSpecification> createTextColumns(String... columns)

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestAuditPasswordAuthenticator.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestAuditPasswordAuthenticator.java
@@ -36,10 +36,12 @@ import org.apache.cassandra.exceptions.AuthenticationException;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static com.ericsson.bss.cassandra.ecaudit.handler.TestAuditQueryHandler.isCloseToNow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.longThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -119,8 +121,8 @@ public class TestAuditPasswordAuthenticator
         assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(negotiator::getAuthenticatedUser);
 
-        verify(mockAdapter, times(1)).auditAuth(eq("username"), eq(clientAddress), eq(Status.ATTEMPT));
-        verify(mockAdapter, times(1)).auditAuth(eq("username"), eq(clientAddress), eq(Status.FAILED));
+        verify(mockAdapter, times(1)).auditAuth(eq("username"), eq(clientAddress), eq(Status.ATTEMPT), longThat(isCloseToNow()));
+        verify(mockAdapter, times(1)).auditAuth(eq("username"), eq(clientAddress), eq(Status.FAILED), longThat(isCloseToNow()));
     }
 
     @Test
@@ -138,8 +140,8 @@ public class TestAuditPasswordAuthenticator
         assertThatExceptionOfType(AuthenticationException.class)
         .isThrownBy(negotiator::getAuthenticatedUser);
 
-        verify(mockAdapter, times(1)).auditAuth(eq("username"), eq(clientAddress), eq(Status.ATTEMPT));
-        verify(mockAdapter, times(1)).auditAuth(eq("username"), eq(clientAddress), eq(Status.FAILED));
+        verify(mockAdapter, times(1)).auditAuth(eq("username"), eq(clientAddress), eq(Status.ATTEMPT), longThat(isCloseToNow()));
+        verify(mockAdapter, times(1)).auditAuth(eq("username"), eq(clientAddress), eq(Status.FAILED), longThat(isCloseToNow()));
     }
 
     @Test
@@ -154,7 +156,7 @@ public class TestAuditPasswordAuthenticator
         negotiator.evaluateResponse(clientResponse);
 
         negotiator.getAuthenticatedUser();
-        verify(mockAdapter, times(1)).auditAuth(eq("user"), eq(clientAddress), eq(Status.ATTEMPT));
+        verify(mockAdapter, times(1)).auditAuth(eq("user"), eq(clientAddress), eq(Status.ATTEMPT), longThat(isCloseToNow()));
     }
 
     @SuppressWarnings("unchecked")

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/config/TestAuditYamlConfigurationLoader.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/config/TestAuditYamlConfigurationLoader.java
@@ -16,6 +16,11 @@
 package com.ericsson.bss.cassandra.ecaudit.config;
 
 import java.net.URL;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -24,6 +29,9 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestAuditYamlConfigurationLoader
 {
@@ -39,6 +47,8 @@ public class TestAuditYamlConfigurationLoader
         .isThrownBy(config::getYamlWhitelist);
         assertThatExceptionOfType(ConfigurationException.class)
         .isThrownBy(config::getLogFormat);
+        assertThatExceptionOfType(ConfigurationException.class)
+        .isThrownBy(config::getTimeFormatter);
     }
 
     @Test
@@ -53,6 +63,8 @@ public class TestAuditYamlConfigurationLoader
         .isThrownBy(config::getYamlWhitelist);
         assertThatExceptionOfType(ConfigurationException.class)
         .isThrownBy(config::getLogFormat);
+        assertThatExceptionOfType(ConfigurationException.class)
+        .isThrownBy(config::getTimeFormatter);
     }
 
     // If ecAudit is configured to use a yaml based whitelist we expect a file to be there
@@ -97,35 +109,99 @@ public class TestAuditYamlConfigurationLoader
     }
 
     @Test
-    public void testMissingDefaultFileForLogFormatIsDefault()
+    public void testSLF4JconfigWhenMissingDefaultFile()
     {
         AuditConfig config = givenLoadedDefaultConfig();
 
         assertThat(config.getLogFormat()).isEqualTo("client:'${CLIENT}'|user:'${USER}'{?|batchId:'${BATCH_ID}'?}|status:'${STATUS}'|operation:'${OPERATION}'");
+        assertThat(config.getTimeFormatter()).isEmpty();
     }
 
     @Test
-    public void testMissingLogFormatIsDefault()
+    public void testSLF4JconfigWhenConfigFileIsEmpty()
     {
         Properties properties = getProperties("empty.yaml");
 
         AuditConfig config = givenLoadedConfig(properties);
 
         assertThat(config.getLogFormat()).isEqualTo("client:'${CLIENT}'|user:'${USER}'{?|batchId:'${BATCH_ID}'?}|status:'${STATUS}'|operation:'${OPERATION}'");
+        assertThat(config.getTimeFormatter()).isEmpty();
     }
 
     @Test
-    public void testLoadingLogFileFormatFromConfiguration()
+    public void testSLF4JconfigWhenLoadingCustomConfiguration()
     {
         Properties properties = getProperties("mock_log_format.yaml");
 
         AuditConfig config = givenLoadedConfig(properties);
 
         assertThat(config.getLogFormat()).isEqualTo("user:{USER}, client:{CLIENT}");
+    }
 
-        AuditYamlConfigurationLoader loader = AuditYamlConfigurationLoader.withProperties(properties);
-        AuditYamlConfig loadedConfig = loader.loadConfig();
-        assertThat(loadedConfig.getLogFormat()).isEqualTo("user:{USER}, client:{CLIENT}");
+    @Test
+    public void testGetTimeFormatterWithFormatAndZoneConfigured()
+    {
+        AuditConfig auditConfig = givenMockedTimeConfig("yyyy-MM-dd HH:mm:ss.SSSZ", "Europe/Stockholm");
+        Optional<DateTimeFormatter> timeFormatter = auditConfig.getTimeFormatter();
+        assertThat(timeFormatter).map(f -> f.format(Instant.EPOCH.plusMillis(42))).contains("1970-01-01 01:00:00.042+0100");
+        assertThat(timeFormatter).map(DateTimeFormatter::getZone).contains(ZoneId.of("Europe/Stockholm"));
+    }
+
+    @Test
+    public void testGetTimeFormatterWithoutZoneConfiguredGetSystemDefault()
+    {
+        AuditConfig auditConfig = givenMockedTimeConfig("yyyy", null);
+        Optional<DateTimeFormatter> timeFormatter = auditConfig.getTimeFormatter();
+        assertThat(timeFormatter).map(DateTimeFormatter::getZone).contains(ZoneId.systemDefault());
+    }
+
+    @Test
+    public void testGetTimeFormatterWithoutFormatConfiguredIsEmpty()
+    {
+        AuditConfig auditConfig = givenMockedTimeConfig(null, "Europe/Stockholm");
+        Optional<DateTimeFormatter> timeFormatter = auditConfig.getTimeFormatter();
+        assertThat(timeFormatter).isEmpty();
+    }
+
+    @Test
+    public void testGetTimeFormatterThrowsExceptionWhenFaultyTimePattern()
+    {
+        AuditConfig auditConfig = givenMockedTimeConfig("]NOK[", "Europe/Stockholm");
+
+        assertThatThrownBy(auditConfig::getTimeFormatter).isInstanceOf(ConfigurationException.class)
+                                                         .hasCauseInstanceOf(IllegalArgumentException.class)
+                                                         .hasMessage("Invalid time format configuration.");
+    }
+
+    @Test
+    public void testGetTimeFormatterThrowsExceptionWhenFaultyTimeZone()
+    {
+        AuditConfig auditConfig = givenMockedTimeConfig("yyyy-MM-dd HH:mm:ss.SSSZ", "DoesNotExist");
+
+        assertThatThrownBy(auditConfig::getTimeFormatter).isInstanceOf(ConfigurationException.class)
+                                                         .hasCauseInstanceOf(DateTimeException.class)
+                                                         .hasMessage("Invalid time zone configuration.");
+    }
+
+    private AuditConfig givenMockedTimeConfig(String timeFormat, String timeZone)
+    {
+        AuditYamlSlf4jConfig slf4jMock = mock(AuditYamlSlf4jConfig.class);
+        if (timeFormat != null)
+        {
+            when(slf4jMock.getTimeFormat()).thenReturn(timeFormat);
+        }
+        if (timeZone != null)
+        {
+            when(slf4jMock.getTimeZone()).thenReturn(timeZone);
+        }
+
+        AuditYamlConfig configMock = mock(AuditYamlConfig.class);
+        when(configMock.getSlf4j()).thenReturn(slf4jMock);
+
+        AuditYamlConfigurationLoader loaderMock = mock(AuditYamlConfigurationLoader.class);
+        when(loaderMock.loadConfig()).thenReturn(configMock);
+
+        return new AuditConfig(loaderMock);
     }
 
     private AuditConfig givenLoadedConfig(Properties properties)

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/entry/TestAuditEntry.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/entry/TestAuditEntry.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.entry;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the {@link AuditEntry} class.
+ */
+public class TestAuditEntry
+{
+    @Test
+    public void testThatBuilderBasedOnPreservesOriginalTimestamp()
+    {
+        // Given
+        AuditEntry originalEntry = newAuditEntryBuilderWithTimestamp(42).build();
+        // When
+        AuditEntry newEntry = AuditEntry.newBuilder().basedOn(originalEntry).build();
+        // Then
+        assertThat(newEntry.getTimestamp()).isEqualTo(42);
+    }
+
+    public static final AuditEntry.Builder newAuditEntryBuilderWithTimestamp(long timestamp)
+    {
+        return new AuditEntry.Builder(timestamp);
+    }
+}

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/entry/TestAuditEntry.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/entry/TestAuditEntry.java
@@ -15,28 +15,57 @@
  */
 package com.ericsson.bss.cassandra.ecaudit.entry;
 
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+
 import org.junit.Test;
 
+import org.apache.cassandra.auth.IResource;
+import org.apache.cassandra.auth.Permission;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests the {@link AuditEntry} class.
  */
 public class TestAuditEntry
 {
+    private static final InetAddress CLIENT = mock(InetAddress.class);
+    private static final Set<Permission> PERMISSIONS = Collections.emptySet();
+    private static final IResource RESOURCE = mock(IResource.class);
+    private static final AuditOperation OPERATION = mock(AuditOperation.class);
+    private static final String USER = "user1";
+    private static final UUID BATCH = mock(UUID.class);
+    private static final Status STATUS = mock(Status.class);
+    private static final long TIMESTAMP = 42L;
+
     @Test
-    public void testThatBuilderBasedOnPreservesOriginalTimestamp()
+    public void testThatBuilderBasedOnPreservesOriginalValues()
     {
         // Given
-        AuditEntry originalEntry = newAuditEntryBuilderWithTimestamp(42).build();
+        AuditEntry auditEntry = AuditEntry.newBuilder()
+                                     .client(CLIENT)
+                                     .permissions(PERMISSIONS)
+                                     .resource(RESOURCE)
+                                     .operation(OPERATION)
+                                     .user(USER)
+                                     .batch(BATCH)
+                                     .status(STATUS)
+                                     .timestamp(TIMESTAMP)
+                                     .build();
         // When
-        AuditEntry newEntry = AuditEntry.newBuilder().basedOn(originalEntry).build();
+        AuditEntry newEntry = AuditEntry.newBuilder().basedOn(auditEntry).build();
         // Then
-        assertThat(newEntry.getTimestamp()).isEqualTo(42);
-    }
-
-    public static final AuditEntry.Builder newAuditEntryBuilderWithTimestamp(long timestamp)
-    {
-        return new AuditEntry.Builder(timestamp);
+        assertThat(auditEntry.getClientAddress()).isSameAs(newEntry.getClientAddress()).isSameAs(CLIENT);
+        assertThat(auditEntry.getPermissions()).isSameAs(newEntry.getPermissions()).isSameAs(PERMISSIONS);
+        assertThat(auditEntry.getResource()).isSameAs(newEntry.getResource()).isSameAs(RESOURCE);
+        assertThat(auditEntry.getOperation()).isSameAs(newEntry.getOperation()).isSameAs(OPERATION);
+        assertThat(auditEntry.getUser()).isSameAs(newEntry.getUser()).isSameAs(USER);
+        assertThat(auditEntry.getBatchId()).isEqualTo(newEntry.getBatchId()).contains(BATCH);
+        assertThat(auditEntry.getStatus()).isSameAs(newEntry.getStatus()).isSameAs(STATUS);
+        assertThat(auditEntry.getTimestamp()).isSameAs(newEntry.getTimestamp()).isSameAs(TIMESTAMP);
     }
 }

--- a/ecaudit/src/test/resources/mock_log_format.yaml
+++ b/ecaudit/src/test/resources/mock_log_format.yaml
@@ -15,4 +15,6 @@
 #
 
 ---
-logFormat: user:{USER}, client:{CLIENT}
+slf4j:
+  logFormat: "user:{USER}, client:{CLIENT}"
+  timeFormat: "yyyy-MM-dd HH:mm:ss.SSS"

--- a/integration-test-custom-format/src/test/resources/integration_audit.yaml
+++ b/integration-test-custom-format/src/test/resources/integration_audit.yaml
@@ -15,4 +15,7 @@
 #
 
 ---
-logFormat: "client=${CLIENT}, user=${USER}, status=${STATUS}, {?batch-id=${BATCH_ID}, ?}operation='${OPERATION}'"
+slf4j:
+  logFormat: "${TIMESTAMP}-> client=${CLIENT}, user=${USER}, status=${STATUS}, {?batch-id=${BATCH_ID}, ?}operation='${OPERATION}'"
+  timeFormat: "yyyy-MM-dd HH:mm:ss.SSS"
+  timeZone: "UTC"


### PR DESCRIPTION
Also restructure the audit.yaml file so that logFormat, timeFormat and timeZone
are configured inside a slf4j section.

Closes #27