### PR TITLE
Use snake_case instead of camelCase for yaml config parameters

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -89,9 +89,9 @@ To configure a custom log message format the following parameters can be configu
 
 | Parameter   | Description                                                       | Default |
 | ----------- | ----------------------------------------------------------------- | --------------- |
-| logFormat   | Parameterized log message formatting string, see examples below  | the "legacy" format, see [README](../README.md) |
-| timeFormat  | time formatter pattern, see examples below or [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns) | number of millis since EPOCH |
-| timeZone    | the time zone id, see examples below or [ZoneId](https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html#of-java.lang.String-) | system default |
+| log_format  | Parameterized log message formatting string, see examples below  | the "legacy" format, see [README](../README.md) |
+| time_format | time formatter pattern, see examples below or [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns) | number of millis since EPOCH |
+| time_zone   | the time zone id, see examples below or [ZoneId](https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html#of-java.lang.String-) | system default |
 
 It is possible to configure a parameterized log message by providing a formatting string.
 The following fields are available:
@@ -116,7 +116,7 @@ Use the example below as a template to define the log message format.
 
 ```YAML
 slf4j:
-  logFormat: "client=${CLIENT}, user=${USER}, status=${STATUS}, operation='${OPERATION}'"
+  log_format: "client=${CLIENT}, user=${USER}, status=${STATUS}, operation='${OPERATION}'"
 ```
 
 Which will generate logs entries like this:
@@ -133,9 +133,9 @@ was part of a batch or not. Also the TIMESTAMP field have a custom time format c
 
 ```YAML
 slf4j:
-  logFormat: "${TIMESTAMP}-> client=${CLIENT}, user=${USER}, status=${STATUS}, {?batch-id=${BATCH_ID}, ?}operation='${OPERATION}'"
-  timeFormat: "yyyy-MM-dd HH:mm:ss.SSS"
-  timeZone: "UTC"
+  log_format: "${TIMESTAMP}-> client=${CLIENT}, user=${USER}, status=${STATUS}, {?batch-id=${BATCH_ID}, ?}operation='${OPERATION}'"
+  time_format: "yyyy-MM-dd HH:mm:ss.SSS"
+  time_zone: "UTC"
 ```
 
 Which will generate logs entries like this (assuming LOGBack pattern does not contain timestamp as well):

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/config/AuditYamlConfig.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/config/AuditYamlConfig.java
@@ -23,9 +23,13 @@ import java.util.List;
  */
 public final class AuditYamlConfig
 {
+    private static final List<String> DEFAULT_WHITELIST = Collections.emptyList();
+
     private boolean fromFile = true;
-    private List<String> whitelist;
-    private AuditYamlSlf4jConfig slf4j;
+
+    // Configuration parameters
+    public List<String> whitelist;
+    public AuditYamlSlf4jConfig slf4j;
 
     static AuditYamlConfig createWithoutFile()
     {
@@ -46,17 +50,7 @@ public final class AuditYamlConfig
      */
     public List<String> getWhitelist()
     {
-        return whitelist != null ? Collections.unmodifiableList(whitelist) : Collections.emptyList();
-    }
-
-    /**
-     * Set the whitelist in this configuration
-     *
-     * @param whitelist a list of whitelisted users
-     */
-    public void setWhitelist(List<String> whitelist)
-    {
-        this.whitelist = whitelist;
+        return whitelist != null ? Collections.unmodifiableList(whitelist) : DEFAULT_WHITELIST;
     }
 
     /**
@@ -65,10 +59,5 @@ public final class AuditYamlConfig
     public AuditYamlSlf4jConfig getSlf4j()
     {
         return slf4j;
-    }
-
-    public void setSlf4j(AuditYamlSlf4jConfig slf4j)
-    {
-        this.slf4j = slf4j;
     }
 }

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/config/AuditYamlSlf4jConfig.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/config/AuditYamlSlf4jConfig.java
@@ -20,26 +20,17 @@ package com.ericsson.bss.cassandra.ecaudit.config;
  */
 public final class AuditYamlSlf4jConfig
 {
-    private String logFormat;
-    private String timeFormat;
-    private String timeZone;
+    // Configuration parameters
+    public String log_format;
+    public String time_format;
+    public String time_zone;
 
     /**
      * @return the log format in this configuration
      */
     public String getLogFormat()
     {
-        return logFormat;
-    }
-
-    /**
-     * Set the log format in this configuration
-     *
-     * @param logFormat the log format string
-     */
-    public void setLogFormat(String logFormat)
-    {
-        this.logFormat = logFormat;
+        return log_format;
     }
 
     /**
@@ -47,17 +38,7 @@ public final class AuditYamlSlf4jConfig
      */
     public String getTimeFormat()
     {
-        return timeFormat;
-    }
-
-    /**
-     * Set the time format in this configuration
-     *
-     * @param timeFormat the time format string
-     */
-    public void setTimeFormat(String timeFormat)
-    {
-        this.timeFormat = timeFormat;
+        return time_format;
     }
 
     /**
@@ -65,16 +46,6 @@ public final class AuditYamlSlf4jConfig
      */
     public String getTimeZone()
     {
-        return timeZone;
-    }
-
-    /**
-     * Set the time zone in this configuration
-     *
-     * @param timeZone the time zone string
-     */
-    public void setTimeZone(String timeZone)
-    {
-        this.timeZone = timeZone;
+        return time_zone;
     }
 }

--- a/ecaudit/src/test/resources/mock_log_format.yaml
+++ b/ecaudit/src/test/resources/mock_log_format.yaml
@@ -16,5 +16,5 @@
 
 ---
 slf4j:
-  logFormat: "user:{USER}, client:{CLIENT}"
-  timeFormat: "yyyy-MM-dd HH:mm:ss.SSS"
+  log_format: "user:{USER}, client:{CLIENT}"
+  time_format: "yyyy-MM-dd HH:mm:ss.SSS"

--- a/integration-test-custom-format/src/test/resources/integration_audit.yaml
+++ b/integration-test-custom-format/src/test/resources/integration_audit.yaml
@@ -16,6 +16,6 @@
 
 ---
 slf4j:
-  logFormat: "${TIMESTAMP}-> client=${CLIENT}, user=${USER}, status=${STATUS}, {?batch-id=${BATCH_ID}, ?}operation='${OPERATION}'"
-  timeFormat: "yyyy-MM-dd HH:mm:ss.SSS"
-  timeZone: "UTC"
+  log_format: "${TIMESTAMP}-> client=${CLIENT}, user=${USER}, status=${STATUS}, {?batch-id=${BATCH_ID}, ?}operation='${OPERATION}'"
+  time_format: "yyyy-MM-dd HH:mm:ss.SSS"
+  time_zone: "UTC"


### PR DESCRIPTION
Rename new log formatting parameters to get same look and fell as Cassandra yaml file:
---
slf4j:
  logFormat -> log_format
  timeFormat -> time_format
  timeZone -> time_zone

Closes #67