### PR TITLE
Wait for schema alignment when audit whitelist table is created

### DIFF
--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/AuditAdapter.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/AuditAdapter.java
@@ -33,6 +33,8 @@ import org.apache.cassandra.cql3.BatchQueryOptions;
 import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.statements.BatchStatement;
+import org.apache.cassandra.exceptions.AuthenticationException;
+import org.apache.cassandra.exceptions.RequestExecutionException;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.utils.MD5Digest;
 
@@ -160,12 +162,13 @@ public class AuditAdapter
     /**
      * Audit an authentication attempt.
      *
-     * @param username the user to authenticate
-     * @param clientIp the address of the client that tries to authenticate
-     * @param status   the status of the operation
+     * @param username  the user to authenticate
+     * @param clientIp  the address of the client that tries to authenticate
+     * @param status    the status of the operation
      * @param timestamp the system timestamp for the request
+     * @throws AuthenticationException if the audit operation could not be performed
      */
-    public void auditAuth(String username, InetAddress clientIp, Status status, long timestamp)
+    public void auditAuth(String username, InetAddress clientIp, Status status, long timestamp) throws AuthenticationException
     {
         AuditEntry logEntry = entryBuilderFactory.createAuthenticationEntryBuilder()
                                                  .client(clientIp)
@@ -175,7 +178,14 @@ public class AuditAdapter
                                                  .timestamp(timestamp)
                                                  .build();
 
-        auditor.audit(logEntry);
+        try
+        {
+            auditor.audit(logEntry);
+        }
+        catch (RequestExecutionException e)
+        {
+            throw new AuthenticationException(e.toString());
+        }
     }
 
     /**

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/Exceptions.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/Exceptions.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.auth;
+
+import org.apache.cassandra.exceptions.CassandraException;
+
+public class Exceptions
+{
+    /**
+     * Try to find a CassandraException which is wrapped in a generic RuntimeException.
+     *
+     * This is useful for instance when cache updates fail asynchronously
+     * with a RuntimeException or an UncheckedExecutionException
+     * that is wrapping a CassandraException which we really want to propagate back to the client.
+     *
+     * The unwrapping procedure will cause valuable back trace to be lost,
+     * and so the original exception is added as a suppressed exception to the CassandraException.
+     *
+     * @param exception the generic RuntimeException
+     * @return the CassandraException if found in the wrapped stack, otherwise the original RuntimeException
+     */
+    public static RuntimeException tryGetCassandraExceptionCause(RuntimeException exception)
+    {
+        Throwable cause = exception.getCause();
+        if (cause instanceof CassandraException)
+        {
+            cause.addSuppressed(exception);
+            return (CassandraException) cause;
+        }
+        else if (cause instanceof RuntimeException)
+        {
+            RuntimeException causeOfCause = tryGetCassandraExceptionCause((RuntimeException) cause);
+
+            if (causeOfCause == cause)
+            {
+                return exception;
+            }
+
+            causeOfCause.addSuppressed(exception);
+            return causeOfCause;
+        }
+        else
+        {
+            return exception;
+        }
+    }
+}

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/SchemaHelper.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/SchemaHelper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.auth;
+
+import java.net.InetAddress;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.gms.ApplicationState;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.VersionedValue;
+import org.apache.cassandra.utils.FBUtilities;
+
+class SchemaHelper
+{
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaHelper.class);
+
+    private final InetAddress localAddress;
+    private final Gossiper gossiper;
+
+    SchemaHelper()
+    {
+        this(FBUtilities.getBroadcastAddress(), Gossiper.instance);
+    }
+
+    @VisibleForTesting
+    SchemaHelper(InetAddress localAddress, Gossiper gossiper)
+    {
+        this.localAddress = localAddress;
+        this.gossiper = gossiper;
+    }
+
+    void waitForSchemaAlignment(int maxTimeToWaitInSeconds)
+    {
+        LOG.info("Waiting for schema to align in cluster");
+        int timeToWaitInSeconds = maxTimeToWaitInSeconds;
+
+        while(areLiveNodesWaitingOnSchemaUpdate() && timeToWaitInSeconds-- > 0)
+        {
+            try
+            {
+                Thread.sleep(1000);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    private boolean areLiveNodesWaitingOnSchemaUpdate()
+    {
+        EndpointState localEndpointState = gossiper.getEndpointStateForEndpoint(localAddress);
+        String localSchemaId = localEndpointState.getApplicationState(ApplicationState.SCHEMA).value;
+
+        for (InetAddress memberAddress : gossiper.getLiveMembers())
+        {
+            if (isRemoteEndpoint(memberAddress))
+            {
+                EndpointState memberEndpointState = gossiper.getEndpointStateForEndpoint(memberAddress);
+                VersionedValue memberVersionedSchema = memberEndpointState.getApplicationState(ApplicationState.SCHEMA);
+                if (isDifferentSchema(localSchemaId, memberVersionedSchema)) {
+                    LOG.debug("Endpoint {} is not aligned yet", memberAddress);
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isRemoteEndpoint(InetAddress memberAddress)
+    {
+        return !memberAddress.equals(localAddress);
+    }
+
+    private boolean isDifferentSchema(String localSchema, VersionedValue versionedValue)
+    {
+        return versionedValue != null && !localSchema.equals(versionedValue.value);
+    }
+}

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/TestAuditAdapter.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/TestAuditAdapter.java
@@ -53,8 +53,11 @@ import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.QueryOptions;
 import org.apache.cassandra.cql3.statements.BatchStatement;
 import org.apache.cassandra.cql3.statements.ModificationStatement;
+import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.dht.IPartitioner;
+import org.apache.cassandra.exceptions.AuthenticationException;
+import org.apache.cassandra.exceptions.ReadTimeoutException;
 import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.utils.MD5Digest;
 import org.mockito.ArgumentCaptor;
@@ -63,8 +66,10 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -491,6 +496,24 @@ public class TestAuditAdapter
         assertThat(captured.getPermissions()).isEqualTo(Sets.immutableEnumSet(Permission.EXECUTE));
         assertThat(captured.getResource()).isEqualTo(ConnectionResource.root());
         assertThat(captured.getTimestamp()).isEqualTo(TIMESTAMP);
+    }
+
+    @Test
+    public void testProcessAuthException()
+    {
+        InetAddress expectedAddress = mock(InetAddress.class);
+        String expectedUser = "user";
+        Status expectedStatus = Status.ATTEMPT;
+
+        when(mockAuditEntryBuilderFactory.createAuthenticationEntryBuilder())
+        .thenReturn(AuditEntry.newBuilder()
+                              .permissions(ImmutableSet.of(Permission.EXECUTE))
+                              .resource(ConnectionResource.root()));
+
+        doThrow(new ReadTimeoutException(ConsistencyLevel.QUORUM, 3, 4, true)).when(mockAuditor).audit(any(AuditEntry.class));
+
+        assertThatExceptionOfType(AuthenticationException.class)
+        .isThrownBy(() -> auditAdapter.auditAuth(expectedUser, expectedAddress, expectedStatus, TIMESTAMP));
     }
 
     private ImmutableList<ColumnSpecification> createTextColumns(String... columns)

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestExceptions.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestExceptions.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.auth;
+
+import org.junit.Test;
+
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.exceptions.ReadTimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestExceptions
+{
+    @Test
+    public void testSimpleRuntimeExceptionIsSame()
+    {
+        RuntimeException expectedException = new RuntimeException();
+
+        RuntimeException actualCause = Exceptions.tryGetCassandraExceptionCause(expectedException);
+
+        assertThat(actualCause).isSameAs(expectedException);
+        assertThat(actualCause.getSuppressed()).isEmpty();
+    }
+
+    @Test
+    public void testSimpleCassandraExceptionIsSame()
+    {
+        RuntimeException expectedException = new ReadTimeoutException(ConsistencyLevel.QUORUM, 1, 1, false);
+
+        RuntimeException actualCause = Exceptions.tryGetCassandraExceptionCause(expectedException);
+
+        assertThat(actualCause).isSameAs(expectedException);
+        assertThat(actualCause.getSuppressed()).isEmpty();
+    }
+
+    @Test
+    public void testWrappedRuntimeExceptionIsSame()
+    {
+        RuntimeException exception = new RuntimeException();
+        RuntimeException expectedException = new RuntimeException(exception);
+
+        RuntimeException actualCause = Exceptions.tryGetCassandraExceptionCause(expectedException);
+
+        assertThat(actualCause).isSameAs(expectedException);
+        assertThat(actualCause.getSuppressed()).isEmpty();
+        assertThat(exception.getSuppressed()).isEmpty();
+    }
+
+    @Test
+    public void testWrappedCassandraExceptionIsUnwrapped()
+    {
+        RuntimeException expectedException = new ReadTimeoutException(ConsistencyLevel.QUORUM, 1, 1, false);
+        RuntimeException exception = new RuntimeException(expectedException);
+
+        RuntimeException actualCause = Exceptions.tryGetCassandraExceptionCause(exception);
+
+        assertThat(actualCause).isSameAs(expectedException);
+        assertThat(actualCause.getSuppressed()).contains(exception);
+        assertThat(exception.getSuppressed()).isEmpty();
+    }
+
+    @Test
+    public void testMultiWrappedCassandraExceptionIsUnwrapped()
+    {
+        RuntimeException expectedException = new ReadTimeoutException(ConsistencyLevel.QUORUM, 1, 1, false);
+        RuntimeException exception = new RuntimeException(expectedException);
+        exception = new RuntimeException(exception);
+
+        RuntimeException actualCause = Exceptions.tryGetCassandraExceptionCause(exception);
+
+        assertThat(actualCause).isSameAs(expectedException);
+        assertThat(actualCause.getSuppressed()).contains(exception);
+        assertThat(exception.getSuppressed()).isEmpty();
+    }
+}

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestSchemaHelper.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestSchemaHelper.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2019 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.auth;
+
+import java.net.InetAddress;
+import java.util.UUID;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.cassandra.config.Config;
+import org.apache.cassandra.gms.ApplicationState;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.VersionedValue;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class TestSchemaHelper
+{
+    @Mock
+    private Gossiper mockGossiper;
+
+    private SchemaHelper schemaHelper;
+
+    private EndpointState localEndpointState;
+    private EndpointState anotherEndpointState;
+
+    private InetAddress remoteEndpoint;
+
+    @BeforeClass
+    public static void beforeClass()
+    {
+        Config.setClientMode(true);
+    }
+
+    @Before
+    public void before() throws Exception
+    {
+        InetAddress localEndpoint = InetAddress.getLoopbackAddress();
+        localEndpointState = createEndpointStateWithSchema();
+        when(mockGossiper.getEndpointStateForEndpoint(eq(localEndpoint))).thenReturn(localEndpointState);
+
+        remoteEndpoint = InetAddress.getByName("127.0.0.2");
+
+        anotherEndpointState = createEndpointStateWithSchema();
+
+        when(mockGossiper.getLiveMembers()).thenReturn(ImmutableSet.of(localEndpoint, remoteEndpoint));
+
+        schemaHelper = new SchemaHelper(localEndpoint, mockGossiper);
+    }
+
+    @AfterClass
+    public static void afterClass()
+    {
+        Config.setClientMode(false);
+    }
+
+    @Test(timeout = 999)
+    public void testSyncedFromStart()
+    {
+        when(mockGossiper.getEndpointStateForEndpoint(eq(remoteEndpoint)))
+        .thenReturn(localEndpointState);
+
+        schemaHelper.waitForSchemaAlignment(10);
+    }
+
+    @Test(timeout = 1999)
+    public void testSyncedAfterOneSecond()
+    {
+        when(mockGossiper.getEndpointStateForEndpoint(eq(remoteEndpoint)))
+        .thenReturn(anotherEndpointState)
+        .thenReturn(localEndpointState);
+
+        long startTime = System.currentTimeMillis();
+
+        schemaHelper.waitForSchemaAlignment(10);
+
+        assertWaitTimeInMillis(startTime, 1000L);
+    }
+
+    @Test(timeout = 1999)
+    public void testSyncTimeout()
+    {
+        when(mockGossiper.getEndpointStateForEndpoint(eq(remoteEndpoint)))
+        .thenReturn(anotherEndpointState);
+
+        long startTime = System.currentTimeMillis();
+
+        schemaHelper.waitForSchemaAlignment(1);
+
+        assertWaitTimeInMillis(startTime, 1000L);
+    }
+
+    private EndpointState createEndpointStateWithSchema()
+    {
+        VersionedValue versionedValue = new VersionedValue.VersionedValueFactory(null).schema(UUID.randomUUID());
+
+        EndpointState endpointState = mock(EndpointState.class);
+        when(endpointState.getApplicationState(eq(ApplicationState.SCHEMA))).thenReturn(versionedValue);
+
+        return endpointState;
+    }
+
+    private void assertWaitTimeInMillis(long startTime, long delay)
+    {
+        long now = System.currentTimeMillis();
+        assertThat(now - startTime).isGreaterThan(delay);
+    }
+}

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/role/TestRoleAuditFilter.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/role/TestRoleAuditFilter.java
@@ -19,10 +19,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,14 +32,19 @@ import org.junit.runner.RunWith;
 import com.ericsson.bss.cassandra.ecaudit.auth.AuditWhitelistCache;
 import com.ericsson.bss.cassandra.ecaudit.auth.ConnectionResource;
 import com.ericsson.bss.cassandra.ecaudit.auth.WhitelistDataAccess;
+import com.ericsson.bss.cassandra.ecaudit.entry.AuditEntry;
 import org.apache.cassandra.auth.DataResource;
 import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.auth.RoleResource;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.exceptions.CassandraException;
+import org.apache.cassandra.exceptions.ReadTimeoutException;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -46,6 +53,9 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class TestRoleAuditFilter
 {
+    @Mock
+    private Function<RoleResource, Set<RoleResource>> getRolesFunctionMock;
+
     @Mock
     private AuditWhitelistCache auditWhitelistCacheMock;
     private Map<RoleResource, Map<IResource, Set<Permission>>> whitelistMap;
@@ -58,7 +68,7 @@ public class TestRoleAuditFilter
     @Before
     public void before()
     {
-        filter = new RoleAuditFilter(auditWhitelistCacheMock, whitelistDataAccessMock);
+        filter = new RoleAuditFilter(getRolesFunctionMock, auditWhitelistCacheMock, whitelistDataAccessMock);
 
         whitelistMap = Maps.newHashMap();
         when(auditWhitelistCacheMock.getWhitelist(any(RoleResource.class)))
@@ -79,32 +89,40 @@ public class TestRoleAuditFilter
     public void primaryRoleWithWhitelistedDataRootDoSelect()
     {
         givenRoleIsWhitelisted("primary", Permission.SELECT, DataResource.root());
-        Set<RoleResource> effectiveRoles = givenRolesOfRequest("primary", "inherited");
-        assertThat(filter.isFiltered(effectiveRoles, Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"))).isEqualTo(true);
+        givenRolesOfRequest("primary", "inherited");
+        AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"));
+
+        assertThat(filter.isFiltered(auditEntry)).isTrue();
     }
 
     @Test
     public void primaryRoleWithWhitelistedKsDoSelect()
     {
         givenRoleIsWhitelisted("primary", Permission.SELECT, DataResource.fromName("data/ks"));
-        Set<RoleResource> effectiveRoles = givenRolesOfRequest("primary", "inherited");
-        assertThat(filter.isFiltered(effectiveRoles, Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"))).isEqualTo(true);
+        givenRolesOfRequest("primary", "inherited");
+        AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"));
+
+        assertThat(filter.isFiltered(auditEntry)).isTrue();
     }
 
     @Test
     public void primaryRoleWithWhitelistedTableDoSelect()
     {
         givenRoleIsWhitelisted("primary", Permission.SELECT, DataResource.fromName("data/ks/tbl"));
-        Set<RoleResource> effectiveRoles = givenRolesOfRequest("primary", "inherited");
-        assertThat(filter.isFiltered(effectiveRoles, Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"))).isEqualTo(true);
+        givenRolesOfRequest("primary", "inherited");
+        AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"));
+
+        assertThat(filter.isFiltered(auditEntry)).isTrue();
     }
 
     @Test
     public void primaryRoleWithWhitelistedTableDoModify()
     {
         givenRoleIsWhitelisted("primary", Permission.MODIFY, DataResource.fromName("data/ks/tbl"));
-        Set<RoleResource> effectiveRoles = givenRolesOfRequest("primary", "inherited");
-        assertThat(filter.isFiltered(effectiveRoles, Collections.singleton(Permission.MODIFY), DataResource.fromName("data/ks/tbl"))).isEqualTo(true);
+        givenRolesOfRequest("primary", "inherited");
+        AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.MODIFY), DataResource.fromName("data/ks/tbl"));
+
+        assertThat(filter.isFiltered(auditEntry)).isTrue();
     }
 
     @Test
@@ -112,8 +130,10 @@ public class TestRoleAuditFilter
     {
         givenRoleIsWhitelisted("primary", Permission.SELECT, DataResource.fromName("data/ks/tbl"));
         givenRoleIsWhitelisted("primary", Permission.MODIFY, DataResource.fromName("data/ks/tbl"));
-        Set<RoleResource> effectiveRoles = givenRolesOfRequest("primary", "inherited");
-        assertThat(filter.isFiltered(effectiveRoles, Sets.newHashSet(Permission.SELECT, Permission.MODIFY), DataResource.fromName("data/ks/tbl"))).isEqualTo(true);
+        givenRolesOfRequest("primary", "inherited");
+        AuditEntry auditEntry = givenAuditEntry(Sets.newHashSet(Permission.SELECT, Permission.MODIFY), DataResource.fromName("data/ks/tbl"));
+
+        assertThat(filter.isFiltered(auditEntry)).isTrue();
     }
 
     @Test
@@ -121,53 +141,78 @@ public class TestRoleAuditFilter
     {
         givenRoleIsWhitelisted("primary", Permission.SELECT, DataResource.fromName("data/ks/tbl"));
         givenRoleIsWhitelisted("inherited", Permission.MODIFY, DataResource.fromName("data/ks/tbl"));
-        Set<RoleResource> effectiveRoles = givenRolesOfRequest("primary", "inherited");
-        assertThat(filter.isFiltered(effectiveRoles, Sets.newHashSet(Permission.SELECT, Permission.MODIFY), DataResource.fromName("data/ks/tbl"))).isEqualTo(true);
+        givenRolesOfRequest("primary", "inherited");
+        AuditEntry auditEntry = givenAuditEntry(Sets.newHashSet(Permission.SELECT, Permission.MODIFY), DataResource.fromName("data/ks/tbl"));
+
+        assertThat(filter.isFiltered(auditEntry)).isTrue();
     }
 
     @Test
     public void primaryRoleWithOtherWhitelistedTableDoSelect()
     {
         givenRoleIsWhitelisted("primary", Permission.SELECT, DataResource.fromName("data/ks/tbl"));
-        Set<RoleResource> effectiveRoles = givenRolesOfRequest("primary", "inherited");
-        assertThat(filter.isFiltered(effectiveRoles, Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/other_tbl"))).isEqualTo(false);
+        givenRolesOfRequest("primary", "inherited");
+        AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/other_tbl"));
+
+        assertThat(filter.isFiltered(auditEntry)).isFalse();
     }
 
     @Test
     public void inheritedRoleWithWhitelistedDataRootDoSelect()
     {
         givenRoleIsWhitelisted("inherited", Permission.SELECT, DataResource.root());
-        Set<RoleResource> effectiveRoles = givenRolesOfRequest("primary", "inherited");
-        assertThat(filter.isFiltered(effectiveRoles, Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"))).isEqualTo(true);
+        givenRolesOfRequest("primary", "inherited");
+        AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"));
+
+        assertThat(filter.isFiltered(auditEntry)).isTrue();
     }
 
     @Test
     public void inheritedRoleWithWhitelistedConnectionDoConnect()
     {
         givenRoleIsWhitelisted("inherited", Permission.EXECUTE, ConnectionResource.root());
-        Set<RoleResource> effectiveRoles = givenRolesOfRequest("primary", "inherited");
-        assertThat(filter.isFiltered(effectiveRoles, Collections.singleton(Permission.EXECUTE), ConnectionResource.root())).isEqualTo(true);
+        givenRolesOfRequest("primary", "inherited");
+        AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.EXECUTE), ConnectionResource.root());
+
+        assertThat(filter.isFiltered(auditEntry)).isTrue();
     }
 
     @Test
     public void roleDoConnect()
     {
-        Set<RoleResource> effectiveRoles = givenRolesOfRequest("primary", "inherited");
-        assertThat(filter.isFiltered(effectiveRoles, Collections.singleton(Permission.EXECUTE), ConnectionResource.root())).isEqualTo(false);
+        givenRolesOfRequest("primary", "inherited");
+        AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.EXECUTE), ConnectionResource.root());
+
+        assertThat(filter.isFiltered(auditEntry)).isFalse();
     }
 
     @Test
     public void roleDoModify()
     {
-        Set<RoleResource> effectiveRoles = givenRolesOfRequest("primary", "inherited");
-        assertThat(filter.isFiltered(effectiveRoles, Collections.singleton(Permission.MODIFY), DataResource.fromName("data/ks/tbl"))).isEqualTo(false);
+        givenRolesOfRequest("primary", "inherited");
+        AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.MODIFY), DataResource.fromName("data/ks/tbl"));
+
+        assertThat(filter.isFiltered(auditEntry)).isFalse();
     }
 
-    private Set<RoleResource> givenRolesOfRequest(String... roleNames)
+    @Test
+    public void uncheckedExceptionIsUnwrapped()
     {
-        return Arrays.stream(roleNames)
-                     .map(RoleResource::role)
-                     .collect(Collectors.toSet());
+        when(getRolesFunctionMock.apply(any(RoleResource.class)))
+        .thenThrow(new UncheckedExecutionException(new RuntimeException(new ReadTimeoutException(ConsistencyLevel.QUORUM, 1, 1, false))));
+        AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"));
+
+        assertThatExceptionOfType(CassandraException.class)
+        .isThrownBy(() -> filter.isFiltered(auditEntry));
+    }
+
+    private void givenRolesOfRequest(String... roleNames)
+    {
+        Set<RoleResource> roles = Arrays.stream(roleNames)
+                                        .map(RoleResource::role)
+                                        .collect(Collectors.toSet());
+
+        when(getRolesFunctionMock.apply(any(RoleResource.class))).thenReturn(roles);
     }
 
     private void givenRoleIsWhitelisted(String roleName, Permission operation, IResource resource)
@@ -187,5 +232,13 @@ public class TestRoleAuditFilter
         Set<Permission> newPermissionSet = permissions != null ? permissions : Sets.newHashSet();
         newPermissionSet.add(permission);
         return newPermissionSet;
+    }
+
+    private AuditEntry givenAuditEntry(Set<Permission> permissions, IResource resource)
+    {
+        return AuditEntry.newBuilder()
+                         .permissions(permissions)
+                         .resource(resource)
+                         .build();
     }
 }


### PR DESCRIPTION
This way queries on the whitelist table will be valid across the cluster once CQL queries are received.

Also, make sure to wrap request exceptions in an authentication exception for authentication audits.
Otherwise the client will be confused.

Closes #57