### PR TITLE
Add timer metrics for auditing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## Version 2.1.0
+* Add metrics for filtering and logging - #72
 * Add support for system timestamp in log message - #27
 * Fix typo of java property for custom audit.yaml path - #59
 * Build with Cassandra 3.11.4 (only flavor ecaudit_c3.11)

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/facade/DefaultAuditor.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/facade/DefaultAuditor.java
@@ -15,9 +15,12 @@
  */
 package com.ericsson.bss.cassandra.ecaudit.facade;
 
+import java.util.concurrent.TimeUnit;
+
 import com.ericsson.bss.cassandra.ecaudit.entry.AuditEntry;
 import com.ericsson.bss.cassandra.ecaudit.filter.AuditFilter;
 import com.ericsson.bss.cassandra.ecaudit.logger.AuditLogger;
+import com.ericsson.bss.cassandra.ecaudit.metrics.AuditMetrics;
 import com.ericsson.bss.cassandra.ecaudit.obfuscator.AuditObfuscator;
 
 /**
@@ -29,15 +32,22 @@ import com.ericsson.bss.cassandra.ecaudit.obfuscator.AuditObfuscator;
  */
 public class DefaultAuditor implements Auditor
 {
-    private AuditLogger logger;
-    private AuditFilter filter;
-    private AuditObfuscator obfuscator;
+    private final AuditLogger logger;
+    private final AuditFilter filter;
+    private final AuditObfuscator obfuscator;
+    private final AuditMetrics auditMetrics;
 
     public DefaultAuditor(AuditLogger logger, AuditFilter filter, AuditObfuscator obfuscator)
+    {
+        this(logger, filter, obfuscator, new AuditMetrics());
+    }
+
+    DefaultAuditor(AuditLogger logger, AuditFilter filter, AuditObfuscator obfuscator, AuditMetrics auditMetrics)
     {
         this.logger = logger;
         this.filter = filter;
         this.obfuscator = obfuscator;
+        this.auditMetrics = auditMetrics;
     }
 
     public void setup()
@@ -48,10 +58,38 @@ public class DefaultAuditor implements Auditor
     @Override
     public void audit(AuditEntry logEntry)
     {
-        if (!filter.isFiltered(logEntry))
+        if (shouldAudit(logEntry))
+        {
+            performAudit(logEntry);
+        }
+    }
+
+    private boolean shouldAudit(AuditEntry logEntry)
+    {
+        long start = System.nanoTime();
+        try
+        {
+            return !filter.isFiltered(logEntry);
+        }
+        finally
+        {
+            long end = System.nanoTime();
+            auditMetrics.filterAuditRequest(end - start, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    private void performAudit(AuditEntry logEntry)
+    {
+        long start = System.nanoTime();
+        try
         {
             AuditEntry obfuscatedEntry = obfuscator.obfuscate(logEntry);
             logger.log(obfuscatedEntry);
+        }
+        finally
+        {
+            long end = System.nanoTime();
+            auditMetrics.auditRequest(end - start, TimeUnit.NANOSECONDS);
         }
     }
 }

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/facade/DefaultAuditor.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/facade/DefaultAuditor.java
@@ -60,7 +60,8 @@ public class DefaultAuditor implements Auditor
     {
         if (shouldAudit(logEntry))
         {
-            performAudit(logEntry);
+            AuditEntry obfuscatedEntry = obfuscator.obfuscate(logEntry);
+            performAudit(obfuscatedEntry);
         }
     }
 
@@ -83,13 +84,12 @@ public class DefaultAuditor implements Auditor
         long start = System.nanoTime();
         try
         {
-            AuditEntry obfuscatedEntry = obfuscator.obfuscate(logEntry);
-            logger.log(obfuscatedEntry);
+            logger.log(logEntry);
         }
         finally
         {
             long end = System.nanoTime();
-            auditMetrics.auditRequest(end - start, TimeUnit.NANOSECONDS);
+            auditMetrics.logAuditRequest(end - start, TimeUnit.NANOSECONDS);
         }
     }
 }

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/metrics/AuditMetrics.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/metrics/AuditMetrics.java
@@ -28,9 +28,8 @@ public class AuditMetrics
 {
     private static final String GROUP_NAME = "com.ericsson.bss.cassandra.ecaudit";
     private static final String METRIC_TYPE = "Audit";
-    private static final String METRIC_SCOPE = "ClientRequests";
-    private static final String METRIC_NAME_FILTER = "AuditFilter";
-    private static final String METRIC_NAME_AUDIT = "Audit";
+    private static final String METRIC_NAME_FILTER = "Filter";
+    private static final String METRIC_NAME_LOG = "Log";
 
     private final Timer auditFilterTimer;
     private final Timer auditTimer;
@@ -42,8 +41,8 @@ public class AuditMetrics
 
     AuditMetrics(Function<CassandraMetricsRegistry.MetricName, Timer> timerFunction)
     {
-        auditFilterTimer = timerFunction.apply(createMetricName(METRIC_TYPE, METRIC_NAME_FILTER, METRIC_SCOPE));
-        auditTimer = timerFunction.apply(createMetricName(METRIC_TYPE, METRIC_NAME_AUDIT, METRIC_SCOPE));
+        auditFilterTimer = timerFunction.apply(createMetricName(METRIC_NAME_FILTER));
+        auditTimer = timerFunction.apply(createMetricName(METRIC_NAME_LOG));
     }
 
     /**
@@ -63,7 +62,7 @@ public class AuditMetrics
      * @param time the time spent logging
      * @param timeUnit the time unit of the provided time
      */
-    public void auditRequest(long time, TimeUnit timeUnit)
+    public void logAuditRequest(long time, TimeUnit timeUnit)
     {
         auditTimer.update(time, timeUnit);
     }
@@ -72,31 +71,21 @@ public class AuditMetrics
      * Copied from org.apache.cassandra.metrics.DefaultNameFactory but with tailored group name.
      * @return a Cassandra metric name
      */
-    private static CassandraMetricsRegistry.MetricName createMetricName(String type, String metricName, String scope)
+    static CassandraMetricsRegistry.MetricName createMetricName(String metricName)
     {
-        return new CassandraMetricsRegistry.MetricName(GROUP_NAME, type, metricName, scope, createMBeanName(type, metricName, scope));
+        return new CassandraMetricsRegistry.MetricName(GROUP_NAME, METRIC_TYPE, metricName, null, createMBeanName(metricName));
     }
 
     /**
-     * Copied from org.apache.cassandra.metrics.DefaultNameFactory but with tailored group name.
+     * Copied from org.apache.cassandra.metrics.DefaultNameFactory but with tailored group name and slightly reduced.
      * @return the name of the mBean.
      */
-    private static String createMBeanName(String type, String name, String scope)
+    private static String createMBeanName(String name)
     {
-        final StringBuilder nameBuilder = new StringBuilder();
-        nameBuilder.append(GROUP_NAME);
-        nameBuilder.append(":type=");
-        nameBuilder.append(type);
-        if (scope != null)
-        {
-            nameBuilder.append(",scope=");
-            nameBuilder.append(scope);
-        }
-        if (name.length() > 0)
-        {
-            nameBuilder.append(",name=");
-            nameBuilder.append(name);
-        }
-        return nameBuilder.toString();
+        return new StringBuilder()
+               .append(GROUP_NAME)
+               .append(":type=").append(METRIC_TYPE)
+               .append(",name=").append(name)
+               .toString();
     }
 }

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/metrics/AuditMetrics.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/metrics/AuditMetrics.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.metrics;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import com.codahale.metrics.Timer;
+import org.apache.cassandra.metrics.CassandraMetricsRegistry;
+
+/**
+ * Helper class to create and update audit metrics.
+ */
+public class AuditMetrics
+{
+    private static final String GROUP_NAME = "com.ericsson.bss.cassandra.ecaudit";
+    private static final String METRIC_TYPE = "Audit";
+    private static final String METRIC_SCOPE = "ClientRequests";
+    private static final String METRIC_NAME_FILTER = "AuditFilter";
+    private static final String METRIC_NAME_AUDIT = "Audit";
+
+    private final Timer auditFilterTimer;
+    private final Timer auditTimer;
+
+    public AuditMetrics()
+    {
+        this(CassandraMetricsRegistry.Metrics::timer);
+    }
+
+    AuditMetrics(Function<CassandraMetricsRegistry.MetricName, Timer> timerFunction)
+    {
+        auditFilterTimer = timerFunction.apply(createMetricName(METRIC_TYPE, METRIC_NAME_FILTER, METRIC_SCOPE));
+        auditTimer = timerFunction.apply(createMetricName(METRIC_TYPE, METRIC_NAME_AUDIT, METRIC_SCOPE));
+    }
+
+    /**
+     * Add timing for filtering a request for audit
+     *
+     * @param time the time spent filtering
+     * @param timeUnit the time unit of the provided time
+     */
+    public void filterAuditRequest(long time, TimeUnit timeUnit)
+    {
+        auditFilterTimer.update(time, timeUnit);
+    }
+
+    /**
+     * Add timing for audit logging of a request.
+     *
+     * @param time the time spent logging
+     * @param timeUnit the time unit of the provided time
+     */
+    public void auditRequest(long time, TimeUnit timeUnit)
+    {
+        auditTimer.update(time, timeUnit);
+    }
+
+    /**
+     * Copied from org.apache.cassandra.metrics.DefaultNameFactory but with tailored group name.
+     * @return a Cassandra metric name
+     */
+    private static CassandraMetricsRegistry.MetricName createMetricName(String type, String metricName, String scope)
+    {
+        return new CassandraMetricsRegistry.MetricName(GROUP_NAME, type, metricName, scope, createMBeanName(type, metricName, scope));
+    }
+
+    /**
+     * Copied from org.apache.cassandra.metrics.DefaultNameFactory but with tailored group name.
+     * @return the name of the mBean.
+     */
+    private static String createMBeanName(String type, String name, String scope)
+    {
+        final StringBuilder nameBuilder = new StringBuilder();
+        nameBuilder.append(GROUP_NAME);
+        nameBuilder.append(":type=");
+        nameBuilder.append(type);
+        if (scope != null)
+        {
+            nameBuilder.append(",scope=");
+            nameBuilder.append(scope);
+        }
+        if (name.length() > 0)
+        {
+            nameBuilder.append(",name=");
+            nameBuilder.append(name);
+        }
+        return nameBuilder.toString();
+    }
+}

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/facade/TestDefaultAuditor.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/facade/TestDefaultAuditor.java
@@ -15,6 +15,8 @@
  */
 package com.ericsson.bss.cassandra.ecaudit.facade;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,11 +25,19 @@ import org.junit.runner.RunWith;
 import com.ericsson.bss.cassandra.ecaudit.entry.AuditEntry;
 import com.ericsson.bss.cassandra.ecaudit.filter.AuditFilter;
 import com.ericsson.bss.cassandra.ecaudit.logger.AuditLogger;
+import com.ericsson.bss.cassandra.ecaudit.metrics.AuditMetrics;
 import com.ericsson.bss.cassandra.ecaudit.obfuscator.AuditObfuscator;
-import org.mockito.InjectMocks;
+import org.apache.cassandra.db.ConsistencyLevel;
+import org.apache.cassandra.exceptions.CassandraException;
+import org.apache.cassandra.exceptions.ReadTimeoutException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -46,12 +56,18 @@ public class TestDefaultAuditor
     @Mock
     private AuditObfuscator mockObfuscator;
 
+    @Mock
+    private AuditMetrics mockAuditMetrics;
+
+    @Captor
+    private ArgumentCaptor<Long> timingCaptor;
+
     private DefaultAuditor auditor;
 
     @Before
     public void before()
     {
-        auditor = new DefaultAuditor(mockLogger, mockFilter, mockObfuscator);
+        auditor = new DefaultAuditor(mockLogger, mockFilter, mockObfuscator, mockAuditMetrics);
     }
 
     @After
@@ -74,9 +90,31 @@ public class TestDefaultAuditor
         AuditEntry logEntry = AuditEntry.newBuilder().build();
         when(mockFilter.isFiltered(logEntry)).thenReturn(true);
 
-        auditor.audit(logEntry);
+        long timeTaken = timedOperation(() -> auditor.audit(logEntry));
+
         verify(mockFilter, times(1)).isFiltered(logEntry);
+        verify(mockAuditMetrics, times(1)).filterAuditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));
+        verifyNoMoreInteractions(mockAuditMetrics);
         verifyZeroInteractions(mockLogger, mockObfuscator);
+
+        long timeMeasured = timingCaptor.getValue();
+        assertThat(timeMeasured).isLessThanOrEqualTo(timeTaken);
+    }
+
+    @Test
+    public void testAuditFilteredThrowsException()
+    {
+        AuditEntry logEntry = AuditEntry.newBuilder().build();
+        when(mockFilter.isFiltered(logEntry)).thenThrow(new ReadTimeoutException(ConsistencyLevel.QUORUM, 1, 1, false));
+
+        long timeTaken = timedOperation(() -> auditor.audit(logEntry), CassandraException.class);
+
+        verify(mockAuditMetrics, times(1)).filterAuditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));
+        verifyNoMoreInteractions(mockAuditMetrics);
+        verifyZeroInteractions(mockLogger, mockObfuscator);
+
+        long timeMeasured = timingCaptor.getValue();
+        assertThat(timeMeasured).isLessThanOrEqualTo(timeTaken);
     }
 
     @Test
@@ -86,9 +124,36 @@ public class TestDefaultAuditor
         when(mockFilter.isFiltered(logEntry)).thenReturn(false);
         when(mockObfuscator.obfuscate(logEntry)).thenReturn(logEntry);
 
-        auditor.audit(logEntry);
+        long timeTaken = timedOperation(() -> auditor.audit(logEntry));
+
         verify(mockFilter, times(1)).isFiltered(logEntry);
         verify(mockObfuscator, times(1)).obfuscate(logEntry);
         verify(mockLogger, times(1)).log(logEntry);
+        verify(mockAuditMetrics, times(1)).filterAuditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));
+        verify(mockAuditMetrics, times(1)).auditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));
+
+        long timeMeasured = timingCaptor.getAllValues().stream().mapToLong(l -> l).sum();
+        assertThat(timeMeasured).isLessThanOrEqualTo(timeTaken);
+    }
+
+    private long timedOperation(Runnable runnable)
+    {
+        return timedOperation(runnable, null);
+    }
+
+    private long timedOperation(Runnable runnable, Class<? extends Exception> expectedExceptionClass)
+    {
+        long start = System.nanoTime();
+
+        if (expectedExceptionClass != null)
+        {
+            assertThatExceptionOfType(expectedExceptionClass).isThrownBy(runnable::run);
+        }
+        else
+        {
+            runnable.run();
+        }
+
+        return System.nanoTime() - start;
     }
 }

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/facade/TestDefaultAuditor.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/facade/TestDefaultAuditor.java
@@ -38,7 +38,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -92,8 +91,8 @@ public class TestDefaultAuditor
 
         long timeTaken = timedOperation(() -> auditor.audit(logEntry));
 
-        verify(mockFilter, times(1)).isFiltered(logEntry);
-        verify(mockAuditMetrics, times(1)).filterAuditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));
+        verify(mockFilter).isFiltered(logEntry);
+        verify(mockAuditMetrics).filterAuditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));
         verifyNoMoreInteractions(mockAuditMetrics);
         verifyZeroInteractions(mockLogger, mockObfuscator);
 
@@ -109,7 +108,7 @@ public class TestDefaultAuditor
 
         long timeTaken = timedOperation(() -> auditor.audit(logEntry), CassandraException.class);
 
-        verify(mockAuditMetrics, times(1)).filterAuditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));
+        verify(mockAuditMetrics).filterAuditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));
         verifyNoMoreInteractions(mockAuditMetrics);
         verifyZeroInteractions(mockLogger, mockObfuscator);
 
@@ -126,11 +125,11 @@ public class TestDefaultAuditor
 
         long timeTaken = timedOperation(() -> auditor.audit(logEntry));
 
-        verify(mockFilter, times(1)).isFiltered(logEntry);
-        verify(mockObfuscator, times(1)).obfuscate(logEntry);
-        verify(mockLogger, times(1)).log(logEntry);
-        verify(mockAuditMetrics, times(1)).filterAuditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));
-        verify(mockAuditMetrics, times(1)).auditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));
+        verify(mockFilter).isFiltered(logEntry);
+        verify(mockObfuscator).obfuscate(logEntry);
+        verify(mockLogger).log(logEntry);
+        verify(mockAuditMetrics).filterAuditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));
+        verify(mockAuditMetrics).logAuditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));
 
         long timeMeasured = timingCaptor.getAllValues().stream().mapToLong(l -> l).sum();
         assertThat(timeMeasured).isLessThanOrEqualTo(timeTaken);

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/metrics/TestAuditMetrics.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/metrics/TestAuditMetrics.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.metrics;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.codahale.metrics.Timer;
+import org.apache.cassandra.metrics.CassandraMetricsRegistry;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class TestAuditMetrics
+{
+    private static final String GROUP_NAME = "com.ericsson.bss.cassandra.ecaudit";
+    private static final String METRIC_TYPE = "Audit";
+    private static final String METRIC_SCOPE = "ClientRequests";
+    private static final String METRIC_NAME_FILTER = "AuditFilter";
+    private static final String METRIC_NAME_AUDIT = "Audit";
+
+    @Mock
+    private Function<CassandraMetricsRegistry.MetricName, Timer> mockTimerFunction;
+
+    @Before
+    public void init()
+    {
+        when(mockTimerFunction.apply(any())).thenReturn(mock(Timer.class));
+    }
+
+    @Test
+    public void testFilterRequestTiming()
+    {
+        Timer mockTimer = mock(Timer.class);
+        CassandraMetricsRegistry.MetricName metric = createMetricName(METRIC_TYPE, METRIC_NAME_FILTER, METRIC_SCOPE);
+
+        when(mockTimerFunction.apply(eq(metric))).thenReturn(mockTimer);
+
+        AuditMetrics auditMetrics = new AuditMetrics(mockTimerFunction);
+        verify(mockTimerFunction, times(1)).apply(eq(metric));
+
+        auditMetrics.filterAuditRequest(999L, TimeUnit.NANOSECONDS);
+        verify(mockTimer, times(1)).update(eq(999L), eq(TimeUnit.NANOSECONDS));
+    }
+
+    @Test
+    public void testAuditRequestTiming()
+    {
+        Timer mockTimer = mock(Timer.class);
+        CassandraMetricsRegistry.MetricName metric = createMetricName(METRIC_TYPE, METRIC_NAME_AUDIT, METRIC_SCOPE);
+
+        when(mockTimerFunction.apply(eq(metric))).thenReturn(mockTimer);
+
+        AuditMetrics auditMetrics = new AuditMetrics(mockTimerFunction);
+        verify(mockTimerFunction, times(1)).apply(eq(metric));
+
+        auditMetrics.auditRequest(999L, TimeUnit.NANOSECONDS);
+        verify(mockTimer, times(1)).update(eq(999L), eq(TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Borrowed from org.apache.cassandra.metrics.DefaultNameFactory but with tailored group name.
+     * @return a Cassandra metric name
+     */
+    private static CassandraMetricsRegistry.MetricName createMetricName(String type, String metricName, String scope)
+    {
+        return new CassandraMetricsRegistry.MetricName(GROUP_NAME, type, metricName, scope, createMBeanName(type, metricName, scope));
+    }
+
+    /**
+     * Borrowed from org.apache.cassandra.metrics.DefaultNameFactory but with tailored group name.
+     * @return the name of the mBean.
+     */
+    private static String createMBeanName(String type, String name, String scope)
+    {
+        final StringBuilder nameBuilder = new StringBuilder();
+        nameBuilder.append(GROUP_NAME);
+        nameBuilder.append(":type=");
+        nameBuilder.append(type);
+        if (scope != null)
+        {
+            nameBuilder.append(",scope=");
+            nameBuilder.append(scope);
+        }
+        if (name.length() > 0)
+        {
+            nameBuilder.append(",name=");
+            nameBuilder.append(name);
+        }
+        return nameBuilder.toString();
+    }
+}


### PR DESCRIPTION
Added timers for how long time it takes to both filter and
log audit entries. These metrics are exposed over JMX as well.

Fixes #72.