### PR TITLE
Configure pitest with naked receiver mutator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <org.apache.maven.plugins.maven-gpg-plugin.version>1.6</org.apache.maven.plugins.maven-gpg-plugin.version>
         <org.eluder.coveralls.coveralls-maven-plugin.version>4.3.0</org.eluder.coveralls.coveralls-maven-plugin.version>
         <org.jacoco.jacoco-maven-plugin.version>0.8.2</org.jacoco.jacoco-maven-plugin.version>
-        <org.pitest.pitest-maven.version>1.4.2</org.pitest.pitest-maven.version>
+        <org.pitest.pitest-maven.version>1.4.6</org.pitest.pitest-maven.version>
     </properties>
 
     <dependencyManagement>
@@ -167,6 +167,10 @@
                     <version>${org.pitest.pitest-maven.version}</version>
                     <configuration>
                         <timestampedReports>false</timestampedReports>
+                         <mutators>
+                            <mutator>DEFAULTS</mutator>
+                            <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                        </mutators>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
The EXPERIMENTAL_NAKED_RECEIVER mutator works well for code contaning
e.g. the builder patterns and the streams api (java8).