### PR TITLE
Remove frozen-brackets from suppressed column data types

### DIFF
--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/suppressor/AbstractSuppressor.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/suppressor/AbstractSuppressor.java
@@ -17,6 +17,8 @@ package com.ericsson.bss.cassandra.ecaudit.entry.suppressor;
 
 import org.apache.cassandra.cql3.ColumnSpecification;
 
+import static com.ericsson.bss.cassandra.ecaudit.utils.Strings.removeFrozenBrackets;
+
 public abstract class AbstractSuppressor implements BoundValueSuppressor
 {
     /**
@@ -25,6 +27,6 @@ public abstract class AbstractSuppressor implements BoundValueSuppressor
      */
     protected String suppressWithType(ColumnSpecification column)
     {
-        return "<" + column.type.asCQL3Type() + ">";
+        return "<" + removeFrozenBrackets(column.type.asCQL3Type().toString()) + ">";
     }
 }

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/utils/Strings.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/utils/Strings.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.utils;
+
+
+import java.util.Deque;
+import java.util.LinkedList;
+
+public final class Strings
+{
+    static final char FROZEN_START = '#';
+
+    private Strings()
+    {
+        // Utility class
+    }
+
+    /**
+     * Remove the "frozen brackets" from a type definition string. The method handles nested frozen types.
+     * <p>
+     * The input {@code "map<int, frozen<list<blob>>>"} will give {@code "map<int, list<blob>>"} as a result.
+     *
+     * @param input type string
+     * @return an "unfrozen" string representation of the type
+     */
+    public static String removeFrozenBrackets(String input)
+    {
+        String unfrozen = input.replaceAll("frozen<", String.valueOf(FROZEN_START));
+        if (input.length() == unfrozen.length())
+        {
+            return input; // input is not frozen
+        }
+        StringBuilder out = new StringBuilder();
+        OpenBrackets openBrackets = new OpenBrackets();
+        for (char c : unfrozen.toCharArray())
+        {
+            switch (c)
+            {
+                case FROZEN_START:
+                    openBrackets.addStartBracket();
+                    openBrackets.increaseAll();
+                    break;
+                case '<':
+                    openBrackets.increaseAll();
+                    out.append(c);
+                    break;
+                case '>':
+                    openBrackets.decreaseAll();
+                    if (!openBrackets.removeLastIfClosed())
+                    {
+                        out.append(c);
+                    }
+                    break;
+                default:
+                    out.append(c);
+                    break;
+            }
+        }
+        return out.toString();
+    }
+
+    static class OpenBrackets
+    {
+        Deque<BracketCount> brackets = new LinkedList<>();
+
+        void addStartBracket()
+        {
+            brackets.addLast(new BracketCount());
+        }
+
+        void increaseAll()
+        {
+            brackets.forEach(BracketCount::increase);
+        }
+
+        void decreaseAll()
+        {
+            brackets.forEach(BracketCount::decrease);
+        }
+
+        boolean removeLastIfClosed()
+        {
+            boolean isLastClosed = !brackets.isEmpty() && brackets.getLast().isClosed();
+            if (isLastClosed)
+            {
+                brackets.removeLast();
+            }
+            return isLastClosed;
+        }
+    }
+
+    static class BracketCount
+    {
+        int count = 0;
+
+        void increase()
+        {
+            count++;
+        }
+
+        void decrease()
+        {
+            count--;
+        }
+
+        boolean isClosed()
+        {
+            return count == 0;
+        }
+    }
+}

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/utils/Strings.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/utils/Strings.java
@@ -18,10 +18,12 @@ package com.ericsson.bss.cassandra.ecaudit.utils;
 
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.regex.Pattern;
 
 public final class Strings
 {
-    static final char FROZEN_START = '#';
+    private static final Pattern FROZEN_PATTERN = Pattern.compile("frozen<");
+    private static final char FROZEN_START = '#';
 
     private Strings()
     {
@@ -38,7 +40,7 @@ public final class Strings
      */
     public static String removeFrozenBrackets(String input)
     {
-        String unfrozen = input.replaceAll("frozen<", String.valueOf(FROZEN_START));
+        String unfrozen = FROZEN_PATTERN.matcher(input).replaceAll(String.valueOf(FROZEN_START));
         if (input.length() == unfrozen.length())
         {
             return input; // input is not frozen

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/entry/suppressor/TestSuppressBlobs.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/entry/suppressor/TestSuppressBlobs.java
@@ -53,6 +53,7 @@ public class TestSuppressBlobs
     private static final ColumnSpecification TEXT_BLOB_MAP_COLUMN = createColumn(mapOf(UTF8Type.instance, BytesType.instance));
     private static final ColumnSpecification TEXT_BLOB_TUPLE_COLUMN = createColumn(tupleOf(UTF8Type.instance, BytesType.instance));
     private static final ColumnSpecification CUSTOM_TYPE_COLUMN = createColumn(customType());
+    private static final ColumnSpecification TEXT_BLOB_LIST_MAP_COLUMN = createColumn(mapOf(UTF8Type.instance, listOf(BytesType.instance)));
 
     private static final ColumnSpecification TEXT_COLUMN = createColumn(UTF8Type.instance);
     private static final ColumnSpecification TEXT_LIST_COLUMN = createColumn(listOf(UTF8Type.instance));
@@ -85,6 +86,7 @@ public class TestSuppressBlobs
         { TEXT_BLOB_MAP_COLUMN, "<map<text, blob>>" },
         { TEXT_BLOB_TUPLE_COLUMN, "<tuple<text, blob>>" },
         { CUSTOM_TYPE_COLUMN, "<'org.apache.cassandra.db.marshal.BytesType'>" },
+        { TEXT_BLOB_LIST_MAP_COLUMN, "<map<text, list<blob>>>" },
         };
     }
 
@@ -120,7 +122,7 @@ public class TestSuppressBlobs
 
     private static <T> ListType<T> listOf(AbstractType<T> type)
     {
-        return ListType.getInstance(type, true);
+        return ListType.getInstance(type, false);
     }
 
     private static <T> SetType<T> setOf(AbstractType<T> type)
@@ -130,7 +132,7 @@ public class TestSuppressBlobs
 
     private static <K, V> MapType<K, V> mapOf(AbstractType<K> keyType, AbstractType<V> valueType)
     {
-        return MapType.getInstance(keyType, valueType, true);
+        return MapType.getInstance(keyType, valueType, false);
     }
 
     private static AbstractType<?> customType()

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/entry/suppressor/TestSuppressRegular.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/entry/suppressor/TestSuppressRegular.java
@@ -21,9 +21,7 @@ import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.apache.cassandra.config.ColumnDefinition;
 import org.apache.cassandra.config.ColumnDefinition.Kind;
-import org.apache.cassandra.cql3.ColumnIdentifier;
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.db.marshal.UTF8Type;
 import org.mockito.Mock;
@@ -31,7 +29,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static com.ericsson.bss.cassandra.ecaudit.entry.suppressor.TestSuppressEverything.createColumnDefinition;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/utils/TestStrings.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/utils/TestStrings.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.utils;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the {@link Strings} class.
+ */
+public class TestStrings
+{
+    @Test
+    public void testNonFrozenString()
+    {
+        String input = "<Kalle>><";
+        String res = Strings.removeFrozenBrackets(input);
+        assertThat(res).isEqualTo(input);
+    }
+
+    @Test
+    public void testNestedFrozenTypes()
+    {
+        String input = "<map<frozen<int>, frozen<list<frozen<blob>>>, frozen<text>>>";
+        String res = Strings.removeFrozenBrackets(input);
+        assertThat(res).isEqualTo("<map<int, list<blob>, text>>");
+    }
+
+    @Test
+    public void testFrozenWithoutBrackets()
+    {
+        String input = "frozen int <>";
+        String res = Strings.removeFrozenBrackets(input);
+        assertThat(res).isEqualTo(input);
+    }
+
+    @Test
+    public void testFrozenWithExtraEndingBrackets()
+    {
+        String input = "frozen<list>>>";
+        String res = Strings.removeFrozenBrackets(input);
+        assertThat(res).isEqualTo("list>>");
+    }
+
+    @Test
+    public void testOpenBrackets()
+    {
+        Strings.OpenBrackets openBrackets = new Strings.OpenBrackets();
+        assertThat(openBrackets.brackets).isEmpty();
+
+        // Given 2 start brackets containing 3 and 1 brackets respectively
+        openBrackets.addStartBracket();
+        openBrackets.increaseAll();
+        openBrackets.increaseAll();
+        openBrackets.addStartBracket();
+        openBrackets.increaseAll();
+
+        assertThat(openBrackets.brackets).hasSize(2);
+        assertThat(openBrackets.brackets.getFirst().count).isEqualTo(3);
+        assertThat(openBrackets.brackets.getLast().count).isEqualTo(1);
+
+        // Removing last is ignored when bracket not closed
+        assertThat(openBrackets.removeLastIfClosed()).isFalse();
+        assertThat(openBrackets.brackets).hasSize(2);
+
+        // Closing the last bracket and removing it
+        openBrackets.decreaseAll();
+        assertThat(openBrackets.removeLastIfClosed()).isTrue();
+        assertThat(openBrackets.brackets).hasSize(1);
+
+        openBrackets.decreaseAll();
+        assertThat(openBrackets.removeLastIfClosed()).isFalse();
+
+        // Closing also the first bracket
+        openBrackets.decreaseAll();
+        assertThat(openBrackets.removeLastIfClosed()).isTrue();
+        assertThat(openBrackets.brackets).isEmpty();
+    }
+}

--- a/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/custom/ITVerifyCustomBoundValueSuppressor.java
+++ b/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/custom/ITVerifyCustomBoundValueSuppressor.java
@@ -153,7 +153,7 @@ public class ITVerifyCustomBoundValueSuppressor
         executePreparedStatement();
         // Then
         assertThat(getLogEntry()).isEqualTo("operation=INSERT INTO ks1.t1 (key1, key2, key3, val1, val2, val3, val4, val5, val6) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)" +
-                                            "['PartKey1', 42, 'ClusterKey', <blob>, <list<blob>>, <map<int, frozen<list<blob>>>>, 43, <tuple<text, blob>>, <mytype>]");
+                                            "['PartKey1', 42, 'ClusterKey', <blob>, <list<blob>>, <map<int, list<blob>>>, 43, <tuple<text, blob>>, <mytype>]");
     }
 
     @Test
@@ -165,7 +165,7 @@ public class ITVerifyCustomBoundValueSuppressor
         executePreparedStatement();
         // Then
         assertThat(getLogEntry()).isEqualTo("operation=INSERT INTO ks1.t1 (key1, key2, key3, val1, val2, val3, val4, val5, val6) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)" +
-                                            "['PartKey1', 42, 'ClusterKey', <blob>, <list<blob>>, <map<int, frozen<list<blob>>>>, <int>, <tuple<text, blob>>, <mytype>]");
+                                            "['PartKey1', 42, 'ClusterKey', <blob>, <list<blob>>, <map<int, list<blob>>>, <int>, <tuple<text, blob>>, <mytype>]");
     }
 
     @Test
@@ -177,7 +177,7 @@ public class ITVerifyCustomBoundValueSuppressor
         executePreparedStatement();
         // Then
         assertThat(getLogEntry()).isEqualTo("operation=INSERT INTO ks1.t1 (key1, key2, key3, val1, val2, val3, val4, val5, val6) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)" +
-                                            "['PartKey1', 42, <text>, <blob>, <list<blob>>, <map<int, frozen<list<blob>>>>, <int>, <tuple<text, blob>>, <mytype>]");
+                                            "['PartKey1', 42, <text>, <blob>, <list<blob>>, <map<int, list<blob>>>, <int>, <tuple<text, blob>>, <mytype>]");
     }
 
     @Test
@@ -189,7 +189,7 @@ public class ITVerifyCustomBoundValueSuppressor
         executePreparedStatement();
         // Then
         assertThat(getLogEntry()).isEqualTo("operation=INSERT INTO ks1.t1 (key1, key2, key3, val1, val2, val3, val4, val5, val6) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)" +
-                                            "[<text>, <int>, <text>, <blob>, <list<blob>>, <map<int, frozen<list<blob>>>>, <int>, <tuple<text, blob>>, <mytype>]");
+                                            "[<text>, <int>, <text>, <blob>, <list<blob>>, <map<int, list<blob>>>, <int>, <tuple<text, blob>>, <mytype>]");
     }
 
     private String getLogEntry()


### PR DESCRIPTION
Frozen brackets are printed for frozen datatypes in column suppressors:
`map<int, frozen<list<blob>>>
`
This change removed the frozen brackets so that only the data types are printed:
`map<int, list<blob>>`