### PR TITLE
Restore 3.11.2 compatibility

### DIFF
--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditWhitelistCache.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditWhitelistCache.java
@@ -18,6 +18,8 @@ package com.ericsson.bss.cassandra.ecaudit.auth;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
 import org.apache.cassandra.auth.AuthCache;
 import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.Permission;
@@ -63,6 +65,15 @@ public class AuditWhitelistCache extends AuthCache<RoleResource, Map<IResource, 
      */
     public Map<IResource, Set<Permission>> getWhitelist(RoleResource role)
     {
-        return get(role);
+        try
+        {
+            return get(role);
+        }
+        catch (Exception e)
+        {
+            // The call to get() may throw ExecutionException in version 3.11.4 and older
+            // We're catching Exception here to remain compatible with those older versions
+            throw new UncheckedExecutionException(e);
+        }
     }
 }


### PR DESCRIPTION
Catching checked exception in AuditWhitelistCache to be campatible with 3.11.2 - 3.11.4.