### PR TITLE
Add possibility for custom fields with the Slf4j logger

### DIFF
--- a/common/src/test/java/com/ericsson/bss/cassandra/ecaudit/common/formatter/TestLogMessageFormatter.java
+++ b/common/src/test/java/com/ericsson/bss/cassandra/ecaudit/common/formatter/TestLogMessageFormatter.java
@@ -23,6 +23,10 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests the {@link LogMessageFormatter} class.
@@ -109,6 +113,21 @@ public class TestLogMessageFormatter
         // Throws when field does not exist
         assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> LogMessageFormatter.getFieldFunctionOrThrow("NON_EXISTING_FIELD", builder))
-        .withMessage("Unknown log format field: NON_EXISTING_FIELD");
+        .withMessage("Unknown log format field and missing fallback: NON_EXISTING_FIELD");
+    }
+
+    @Test
+    public void testGetFieldFunctionOrThrowWithFallback()
+    {
+        // Given
+        LogMessageFormatter.Builder.FallbackFieldFunction fallback = mock(LogMessageFormatter.Builder.FallbackFieldFunction.class);
+        LogMessageFormatter.Builder builder = LogMessageFormatter.<Integer>builder().availableFields(TEST_FIELDS).fallbackFunction(fallback);
+
+        // When
+        Function nonExistingFieldFunction = LogMessageFormatter.getFieldFunctionOrThrow("NON_EXISTING_FIELD", builder);
+        nonExistingFieldFunction.apply(4711);
+
+        // Then
+        verify(fallback, times(1)).apply(eq("NON_EXISTING_FIELD"), eq(4711));
     }
 }

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/AuditAdapter.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/AuditAdapter.java
@@ -205,6 +205,19 @@ public class AuditAdapter
         }
     }
 
+    /**
+     * Audit log a specific, custom made entry.
+     * @param entry the entry to log
+     */
+    public void audit(AuditEntry entry)
+    {
+        Status status = entry.getStatus();
+        if (auditor.shouldLogForStatus(status))
+        {
+            auditor.audit(entry);
+        }
+    }
+
     static SimpleAuditOperation statusToAuthenticationOperation(Status status)
     {
         return new SimpleAuditOperation("Authentication " + status.getDisplayName());

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/entry/TestAuditEntry.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/entry/TestAuditEntry.java
@@ -15,21 +15,23 @@
  */
 package com.ericsson.bss.cassandra.ecaudit.entry;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import org.apache.cassandra.auth.IResource;
+import org.apache.cassandra.auth.Permission;
 import org.junit.Test;
 
 import com.ericsson.bss.cassandra.ecaudit.common.record.AuditOperation;
 import com.ericsson.bss.cassandra.ecaudit.common.record.Status;
-import org.apache.cassandra.auth.IResource;
-import org.apache.cassandra.auth.Permission;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 /**
  * Tests the {@link AuditEntry} class.
@@ -46,21 +48,25 @@ public class TestAuditEntry
     private static final Status STATUS = mock(Status.class);
     private static final long TIMESTAMP = 42L;
 
+    private static final String CUSTOM_FIELD = "customField";
+    private static final String CUSTOM_VALUE = "value";
+
     @Test
     public void testThatBuilderBasedOnPreservesOriginalValues()
     {
         // Given
         AuditEntry auditEntry = AuditEntry.newBuilder()
-                                          .client(CLIENT)
-                                          .coordinator(COORDINATOR)
-                                          .permissions(PERMISSIONS)
-                                          .resource(RESOURCE)
-                                          .operation(OPERATION)
-                                          .user(USER)
-                                          .batch(BATCH)
-                                          .status(STATUS)
-                                          .timestamp(TIMESTAMP)
-                                          .build();
+                .client(CLIENT)
+                .coordinator(COORDINATOR)
+                .permissions(PERMISSIONS)
+                .resource(RESOURCE)
+                .operation(OPERATION)
+                .user(USER)
+                .batch(BATCH)
+                .status(STATUS)
+                .timestamp(TIMESTAMP)
+                .with(CUSTOM_FIELD, CUSTOM_VALUE)
+                .build();
         // When
         AuditEntry newEntry = AuditEntry.newBuilder().basedOn(auditEntry).build();
         // Then
@@ -73,5 +79,49 @@ public class TestAuditEntry
         assertThat(auditEntry.getBatchId()).isEqualTo(newEntry.getBatchId()).contains(BATCH);
         assertThat(auditEntry.getStatus()).isSameAs(newEntry.getStatus()).isSameAs(STATUS);
         assertThat(auditEntry.getTimestamp()).isSameAs(newEntry.getTimestamp()).isSameAs(TIMESTAMP);
+        assertThat(auditEntry.get(CUSTOM_FIELD, String.class)).isSameAs(CUSTOM_VALUE);
+    }
+
+    @Test
+    public void testThatCustomFieldsOnlyReturnCustomFields()
+    {
+        // Given
+        AuditEntry auditEntry = AuditEntry.newBuilder()
+                .client(CLIENT)
+                .coordinator(COORDINATOR)
+                .permissions(PERMISSIONS)
+                .resource(RESOURCE)
+                .operation(OPERATION)
+                .user(USER)
+                .batch(BATCH)
+                .status(STATUS)
+                .timestamp(TIMESTAMP)
+                .with(CUSTOM_FIELD, CUSTOM_VALUE)
+                .build();
+        // When
+        AuditEntry newEntry = AuditEntry.newBuilder().basedOn(auditEntry).build();
+
+        // Then
+        Map<String, Object> customFields = newEntry.customFields();
+        assertThat(customFields.size()).isEqualTo(1);
+        assertThat(customFields.get(CUSTOM_FIELD)).isSameAs(CUSTOM_VALUE);
+    }
+
+    @Test
+    public void testThatCustomFieldIsNotAllowedToOverwriteReservedKey()
+    {
+        AuditEntry.RESERVED_KEYS.forEach(reservedKey -> {
+            AuditEntry.Builder builder = AuditEntry.newBuilder();
+            try
+            {
+                builder = builder.with(reservedKey, CUSTOM_FIELD);
+                fail("Did not fail on overwriting field: " + reservedKey);
+            }
+            catch(IllegalArgumentException e)
+            {
+                AuditEntry entry = builder.build();
+                assertThat(entry.get(reservedKey, String.class)).isNull();
+            }
+        });
     }
 }


### PR DESCRIPTION
This makes it possible to build an audit log entry programatically
with custom fields, and log it with a custom logging format.