### PR TITLE
Grants based whitelist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## Version 2.4.0
+* Make sure authorized user can whitelist himself - #145
+
 ## Version 2.3.0
 * Fix announcement of internal table (only flavor ecaudit_c3.0 and ecaudit_c3.11) - #137
 * Build with Cassandra 3.11.6 (only flavor ecaudit_c3.11)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.4.0
 * Make sure authorized user can whitelist himself - #145
+* Introduce grants-based role white-listing
 
 ## Version 2.3.0
 * Fix announcement of internal table (only flavor ecaudit_c3.0 and ecaudit_c3.11) - #137

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditAuthorizer.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditAuthorizer.java
@@ -134,4 +134,9 @@ public class AuditAuthorizer implements IAuthorizer
     {
         wrappedAuthorizer.setup();
     }
+
+    public IAuthorizer getWrappedAuthorizer()
+    {
+        return wrappedAuthorizer;
+    }
 }

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditRoleManager.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditRoleManager.java
@@ -84,7 +84,7 @@ public class AuditRoleManager implements IRoleManager
                            ? ImmutableSet.of(Option.LOGIN, Option.SUPERUSER, Option.PASSWORD, Option.OPTIONS)
                            : ImmutableSet.of(Option.LOGIN, Option.SUPERUSER);
         alterableOptions = hasAuditPasswordAuthenticator
-                           ? ImmutableSet.of(Option.PASSWORD)
+                           ? ImmutableSet.of(Option.PASSWORD, Option.OPTIONS)
                            : ImmutableSet.of();
     }
 

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditWhitelistManager.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/AuditWhitelistManager.java
@@ -163,11 +163,17 @@ class AuditWhitelistManager
 
     private static void checkPermissionToWhitelist(AuthenticatedUser performer, IResource resource)
     {
-        Set<Permission> userPermissions = performer.getPermissions(resource);
-        if (!userPermissions.contains(Permission.AUTHORIZE))
+        if (!performer.isSuper())
         {
-            throw new UnauthorizedException(String.format("User %s is not authorized to whitelist access to %s",
-                                                          performer.getName(), resource));
+            IResource actualResource = resource instanceof GrantResource
+                                       ? ((GrantResource) resource).getWrappedResource()
+                                       : resource;
+
+            if (actualResource == null || !performer.getPermissions(actualResource).contains(Permission.AUTHORIZE))
+            {
+                throw new UnauthorizedException(String.format("User %s is not authorized to whitelist access to %s",
+                                                              performer.getName(), resource));
+            }
         }
     }
 }

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/GrantResource.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/GrantResource.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.auth;
+
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.cassandra.auth.IResource;
+import org.apache.cassandra.auth.Permission;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * IResource implementation representing a grant on the wrapped resource.
+ * <p>
+ * The resource {@code grants/data/myKeyspace/myTable} represents a <i>grant</i> on the <i>wrapped resource</i>
+ * {@code data/myKeyspace/myTable}
+ * <p>
+ * The "root-level" grant is returned by the {@link GrantResource#root()} method.
+ */
+public final class GrantResource implements IResource
+{
+    private static final GrantResource ROOT_LEVEL = new GrantResource(null);
+    private static final String ROOT_NAME = "grants";
+
+    private final IResource wrappedResource;
+
+    private GrantResource(IResource wrappedResource)
+    {
+        this.wrappedResource = wrappedResource;
+    }
+
+    /**
+     * @param resource the resource to wrap, must not be {@code null}
+     * @return a new grant resource with the provided resource wrapped inside
+     */
+    public static GrantResource fromResource(IResource resource)
+    {
+        return new GrantResource(checkNotNull(resource));
+    }
+
+    IResource getWrappedResource()
+    {
+        return wrappedResource;
+    }
+
+    /**
+     * @return the root-level resource.
+     */
+    public static GrantResource root()
+    {
+        return ROOT_LEVEL;
+    }
+
+    @Override
+    public String getName()
+    {
+        return wrappedResource == null
+               ? ROOT_NAME
+               : ROOT_NAME + "/" + wrappedResource.getName();
+    }
+
+    /**
+     * This method should not be used to travers the resource hierarchy. Use {@link #getWrappedResource()} instead.
+     */
+    @Override
+    public IResource getParent()
+    {
+        throw new IllegalStateException("Root-level resource can't have a parent");
+    }
+
+    /**
+     * This method should not be used to travers the resource hierarchy. Use {@link #getWrappedResource()} instead.
+     */
+    @Override
+    public boolean hasParent()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean exists()
+    {
+        return wrappedResource == null || wrappedResource.exists();
+    }
+
+    @Override
+    public Set<Permission> applicablePermissions()
+    {
+        return wrappedResource == null
+               ? Permission.ALL
+               : wrappedResource.applicablePermissions();
+    }
+
+    @Override
+    public String toString()
+    {
+        return wrappedResource == null
+               ? "<grants [all resources]>"
+               : String.format("<grants [%s]>", wrappedResource);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        GrantResource that = (GrantResource) o;
+        return Objects.equals(wrappedResource, that.wrappedResource);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(wrappedResource);
+    }
+}

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/ResourceFactory.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/auth/ResourceFactory.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.cassandra.auth.DataResource;
@@ -33,6 +34,7 @@ final class ResourceFactory
     private static final String ROLES_ROOT = "roles";
     private static final String CONNECTIONS_ROOT = "connections";
     private static final String FUNCTIONS_ROOT = "functions";
+    private static final String GRANT_ROOT = "grants";
 
     private static final String SEPARATOR = "/";
     private static final Pattern VALID_NAME_PATTERN = Pattern.compile("\\w+");
@@ -80,6 +82,15 @@ final class ResourceFactory
                 FunctionResource functionResource = FunctionResource.fromName(resourceName);
                 validateFunctionResourceName(functionResource);
                 return functionResource;
+            case GRANT_ROOT:
+                if (parts.length == 1)
+                {
+                    return GrantResource.root();
+                }
+                String wrappedResourceName = parts[1];
+                Preconditions.checkArgument(!wrappedResourceName.startsWith(GRANT_ROOT), "Invalid resource type: %s, recursive grants not allowed", resourceName);
+                IResource wrappedResource = toResource(wrappedResourceName);
+                return GrantResource.fromResource(wrappedResource);
             default:
                 throw new IllegalArgumentException("Invalid resource type: " + resourceName);
         }

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/facade/DefaultAuditor.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/facade/DefaultAuditor.java
@@ -77,7 +77,7 @@ public class DefaultAuditor implements Auditor
         long start = System.nanoTime();
         try
         {
-            return !filter.isFiltered(logEntry);
+            return !filter.isWhitelisted(logEntry);
         }
         finally
         {

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/AuditFilter.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/AuditFilter.java
@@ -23,13 +23,13 @@ import com.ericsson.bss.cassandra.ecaudit.entry.AuditEntry;
 public interface AuditFilter {
 
     /**
-     * Return a boolean indicating whether the given log entry is to be exempt from audit logging (i.e. it is filtered).
+     * Return a boolean indicating whether the given log entry is to be exempt from audit logging (i.e. it is whitelisted).
      *
      * @param logEntry
      *            the log entry to check if filtered
      * @return true if the log entry is exempt from audit
      */
-    boolean isFiltered(AuditEntry logEntry);
+    boolean isWhitelisted(AuditEntry logEntry);
 
     /**
      * Setup is called once upon system startup to initialize the AuditFilter.

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/DefaultAuditFilter.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/DefaultAuditFilter.java
@@ -23,7 +23,7 @@ import com.ericsson.bss.cassandra.ecaudit.entry.AuditEntry;
 public class DefaultAuditFilter implements AuditFilter {
 
     @Override
-    public boolean isFiltered(AuditEntry logEntry) {
+    public boolean isWhitelisted(AuditEntry logEntry) {
         return false;
     }
 

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/role/AuditFilterAuthorizer.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/role/AuditFilterAuthorizer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.filter.role;
+
+import java.util.List;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.ericsson.bss.cassandra.ecaudit.auth.AuditAuthorizer;
+import com.ericsson.bss.cassandra.ecaudit.utils.AuthenticatedUserUtil;
+import org.apache.cassandra.auth.AuthenticatedUser;
+import org.apache.cassandra.auth.IAuthorizer;
+import org.apache.cassandra.auth.IResource;
+import org.apache.cassandra.auth.Permission;
+import org.apache.cassandra.config.DatabaseDescriptor;
+
+public class AuditFilterAuthorizer
+{
+    private IAuthorizer authorizer; // lazy initialization
+
+    public boolean isOperationAuthorizedForUser(Permission operation, String user, List<? extends IResource> resourceChain)
+    {
+        AuthenticatedUser authUser = AuthenticatedUserUtil.createFromString(user);
+        IAuthorizer authorizer = getAuthorizer();
+        return resourceChain.stream()
+                     .map(resource -> authorizer.authorize(authUser, resource))
+                     .anyMatch(permissions -> permissions.contains(operation));
+    }
+
+    @VisibleForTesting
+    void setAuthorizer(IAuthorizer authorizer)
+    {
+        this.authorizer = authorizer;
+    }
+
+    IAuthorizer getAuthorizer()
+    {
+        if (authorizer == null)
+        {
+            resolveAuthorizerSync();
+        }
+        return authorizer;
+    }
+
+    private synchronized void resolveAuthorizerSync()
+    {
+        if (authorizer == null)
+        {
+            IAuthorizer currentAuthorizer = DatabaseDescriptor.getAuthorizer();
+            if (currentAuthorizer instanceof AuditAuthorizer)
+            {
+                // AuditAuthorizer adds the ALTER permission, so we must use the wrapped Authorizer instead
+                currentAuthorizer = ((AuditAuthorizer) currentAuthorizer).getWrappedAuthorizer();
+            }
+            authorizer = currentAuthorizer;
+        }
+    }
+}

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/role/RoleAuditFilter.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/role/RoleAuditFilter.java
@@ -77,11 +77,11 @@ public class RoleAuditFilter implements AuditFilter
      * @return true if the operation is white-listed, false otherwise
      */
     @Override
-    public boolean isFiltered(AuditEntry logEntry)
+    public boolean isWhitelisted(AuditEntry logEntry)
     {
         try
         {
-            return isFilteredUnchecked(logEntry);
+            return isWhitelistedUnchecked(logEntry);
         }
         catch (UncheckedExecutionException e)
         {
@@ -89,7 +89,7 @@ public class RoleAuditFilter implements AuditFilter
         }
     }
 
-    private boolean isFilteredUnchecked(AuditEntry logEntry)
+    private boolean isWhitelistedUnchecked(AuditEntry logEntry)
     {
         Set<RoleResource> roles = getRoles(logEntry.getUser());
         List<? extends IResource> operationResourceChain = Resources.chain(logEntry.getResource());

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/role/RoleWhitelistChecker.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/role/RoleWhitelistChecker.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.filter.role;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.ericsson.bss.cassandra.ecaudit.auth.GrantResource;
+import org.apache.cassandra.auth.IResource;
+import org.apache.cassandra.auth.Permission;
+
+class RoleWhitelistChecker
+{
+    private final Map<IResource, Set<Permission>> whitelist;
+    private final List<? extends IResource> resourceChain;
+    private final Permission operation;
+
+    RoleWhitelistChecker(Permission operation, List<? extends IResource> resourceChain, Map<IResource, Set<Permission>> whitelist)
+    {
+        this.operation = operation;
+        this.resourceChain = resourceChain;
+        this.whitelist = whitelist;
+    }
+
+    boolean isWhitelisted()
+    {
+        return anyResourceMatchPermission(resourceChain);
+    }
+
+    boolean isGrantWhitelisted()
+    {
+        List<GrantResource> grantResourceChain = resourceChain.stream()
+                                                              .map(GrantResource::fromResource)
+                                                              .collect(Collectors.toCollection(ArrayList::new));
+        grantResourceChain.add(GrantResource.root());
+
+        return anyResourceMatchPermission(grantResourceChain);
+    }
+
+    private boolean anyResourceMatchPermission(List<? extends IResource> resourceChain)
+    {
+        return resourceChain.stream()
+                            .map(whitelist::get)
+                            .filter(Objects::nonNull)
+                            .anyMatch(whitelistedOperations -> whitelistedOperations.contains(operation));
+    }
+}

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/yaml/YamlAuditFilter.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/yaml/YamlAuditFilter.java
@@ -36,7 +36,7 @@ public class YamlAuditFilter implements AuditFilter
     }
 
     @Override
-    public boolean isFiltered(AuditEntry logEntry)
+    public boolean isWhitelisted(AuditEntry logEntry)
     {
         // When using YAML-based whitelist, always audit log authentication operations
         if (logEntry.getResource() instanceof ConnectionResource)

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/yamlandrole/YamlAndRoleAuditFilter.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/yamlandrole/YamlAndRoleAuditFilter.java
@@ -46,9 +46,9 @@ public class YamlAndRoleAuditFilter implements AuditFilter
     }
 
     @Override
-    public boolean isFiltered(AuditEntry logEntry)
+    public boolean isWhitelisted(AuditEntry logEntry)
     {
-        return yamlFilter.isFiltered(logEntry) || roleFilter.isFiltered(logEntry);
+        return yamlFilter.isWhitelisted(logEntry) || roleFilter.isWhitelisted(logEntry);
     }
 
     @Override

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/utils/AuthenticatedUserUtil.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/utils/AuthenticatedUserUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.utils;
+
+import org.apache.cassandra.auth.AuthenticatedUser;
+
+public final class AuthenticatedUserUtil
+{
+   private  AuthenticatedUserUtil()
+   {
+       // Utility class
+   }
+
+    /**
+     * Creates an AuthenticatedUser from the given string.
+     * Makes sure the correct constants for system/anonymous users are used. This ensures that the
+     * {@link AuthenticatedUser#isSystem()} and {@link AuthenticatedUser#isAnonymous()} methods work correctly.
+     *
+     * @param user the user
+     * @return the created authenticated user
+     */
+   public static AuthenticatedUser createFromString(String user)
+   {
+       switch (user)
+       {
+           case AuthenticatedUser.SYSTEM_USERNAME:
+               return AuthenticatedUser.SYSTEM_USER;
+           case AuthenticatedUser.ANONYMOUS_USERNAME:
+               return AuthenticatedUser.ANONYMOUS_USER;
+           default:
+               return new AuthenticatedUser(user);
+       }
+   }
+}

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestAuditRoleManager.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestAuditRoleManager.java
@@ -115,7 +115,7 @@ public class TestAuditRoleManager
     {
         Set<IRoleManager.Option> options = auditRoleManager.alterableOptions();
 
-        assertThat(options).containsExactlyElementsOf(ImmutableSet.of(IRoleManager.Option.PASSWORD));
+        assertThat(options).containsExactlyElementsOf(ImmutableSet.of(IRoleManager.Option.PASSWORD, IRoleManager.Option.OPTIONS));
     }
 
     @Test

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestGrantResource.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestGrantResource.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.auth;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ericsson.bss.cassandra.ecaudit.test.mode.ClientInitializer;
+import org.apache.cassandra.auth.DataResource;
+import org.apache.cassandra.auth.IResource;
+import org.apache.cassandra.auth.Permission;
+import org.apache.cassandra.auth.RoleResource;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestGrantResource
+{
+    @Test
+    public void testRootLevelGrant()
+    {
+        GrantResource root = GrantResource.root();
+
+        assertThat(root.getName()).isEqualTo("grants");
+        assertThat(root.exists()).isTrue();
+        assertThat(root.hasParent()).isFalse();
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(root::getParent);
+        assertThat(root.applicablePermissions()).isEqualTo(Permission.ALL);
+        assertThat(root.getWrappedResource()).isNull();
+    }
+
+    @Test
+    public void testDataGrant()
+    {
+        DataResource dataResource = DataResource.fromName("data/ks/tbl");
+        GrantResource resource = GrantResource.fromResource(dataResource);
+
+        assertThat(resource.getName()).isEqualTo("grants/data/ks/tbl");
+        assertThat(resource.hasParent()).isFalse();
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(resource::getParent);
+        assertThat(resource.applicablePermissions()).isEqualTo(dataResource.applicablePermissions());
+        assertThat(resource.getWrappedResource()).isEqualTo(dataResource);
+    }
+
+    @Test
+    public void testRolesGrant()
+    {
+        RoleResource roleResource = RoleResource.fromName("roles/kalle");
+        GrantResource resource = GrantResource.fromResource(roleResource);
+
+        assertThat(resource.getName()).isEqualTo("grants/roles/kalle");
+        assertThat(resource.hasParent()).isFalse();
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(resource::getParent);
+        assertThat(resource.applicablePermissions()).isEqualTo(roleResource.applicablePermissions());
+        assertThat(resource.getWrappedResource()).isEqualTo(roleResource);
+    }
+
+    @Test
+    public void testExists()
+    {
+        IResource wrappedResourceMock = mock(IResource.class);
+        when(wrappedResourceMock.exists()).thenReturn(true, false);
+        GrantResource resource = GrantResource.fromResource(wrappedResourceMock);
+        assertThat(resource.exists()).isTrue();
+        assertThat(resource.exists()).isFalse();
+    }
+
+    @Test
+    public void testWrappingNullResourceThrows()
+    {
+        assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> GrantResource.fromResource(null));
+    }
+}

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestResourceFactory.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/auth/TestResourceFactory.java
@@ -166,6 +166,36 @@ public class TestResourceFactory
     }
 
     @Test
+    public void testGrantsRoot()
+    {
+        IResource resource = ResourceFactory.toResource("grants");
+        assertThat(resource).isSameAs(GrantResource.root());
+    }
+
+    @Test
+    public void testGrantsWrappedResource()
+    {
+        IResource resource = ResourceFactory.toResource("grants/data/ks/table");
+        assertThat(resource.getName()).isEqualTo("grants/data/ks/table");
+        assertThat(resource).isInstanceOf(GrantResource.class);
+    }
+
+    @Test
+    public void testGrantsFail()
+    {
+        assertThatIllegalArgumentException()
+        .isThrownBy(() -> ResourceFactory.toResource("grants/invalid"));
+    }
+
+    @Test
+    public void testRecursiveGrantsFail()
+    {
+        assertThatIllegalArgumentException()
+        .isThrownBy(() -> ResourceFactory.toResource("grants/grants/data/ks/table"))
+        .withMessageContaining("Invalid resource type: grants/grants/data/ks/table, recursive grants not allowed");
+    }
+
+    @Test
     public void testInvalidResourceType()
     {
         assertThatIllegalArgumentException()

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/facade/TestDefaultAuditor.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/facade/TestDefaultAuditor.java
@@ -96,11 +96,11 @@ public class TestDefaultAuditor
     public void testAuditFiltered()
     {
         AuditEntry logEntry = AuditEntry.newBuilder().build();
-        when(mockFilter.isFiltered(logEntry)).thenReturn(true);
+        when(mockFilter.isWhitelisted(logEntry)).thenReturn(true);
 
         long timeTaken = timedOperation(() -> auditor.audit(logEntry));
 
-        verify(mockFilter).isFiltered(logEntry);
+        verify(mockFilter).isWhitelisted(logEntry);
         verify(mockAuditMetrics).filterAuditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));
         verifyNoMoreInteractions(mockAuditMetrics);
         verifyZeroInteractions(mockLogger, mockObfuscator);
@@ -113,7 +113,7 @@ public class TestDefaultAuditor
     public void testAuditFilteredThrowsException()
     {
         AuditEntry logEntry = AuditEntry.newBuilder().build();
-        when(mockFilter.isFiltered(logEntry)).thenThrow(new ReadTimeoutException(ConsistencyLevel.QUORUM, 1, 1, false));
+        when(mockFilter.isWhitelisted(logEntry)).thenThrow(new ReadTimeoutException(ConsistencyLevel.QUORUM, 1, 1, false));
 
         long timeTaken = timedOperation(() -> auditor.audit(logEntry), CassandraException.class);
 
@@ -129,12 +129,12 @@ public class TestDefaultAuditor
     public void testAuditNotFiltered()
     {
         AuditEntry logEntry = AuditEntry.newBuilder().build();
-        when(mockFilter.isFiltered(logEntry)).thenReturn(false);
+        when(mockFilter.isWhitelisted(logEntry)).thenReturn(false);
         when(mockObfuscator.obfuscate(logEntry)).thenReturn(logEntry);
 
         long timeTaken = timedOperation(() -> auditor.audit(logEntry));
 
-        verify(mockFilter).isFiltered(logEntry);
+        verify(mockFilter).isWhitelisted(logEntry);
         verify(mockObfuscator).obfuscate(logEntry);
         verify(mockLogger).log(logEntry);
         verify(mockAuditMetrics).filterAuditRequest(timingCaptor.capture(), eq(TimeUnit.NANOSECONDS));

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/TestDefaultAuditFilter.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/TestDefaultAuditFilter.java
@@ -34,8 +34,8 @@ public class TestDefaultAuditFilter
     {
         DefaultAuditFilter filter = new DefaultAuditFilter();
 
-        assertThat(filter.isFiltered(toLogEntry("user1"))).isFalse();
-        assertThat(filter.isFiltered(toLogEntry("user2"))).isFalse();
+        assertThat(filter.isWhitelisted(toLogEntry("user1"))).isFalse();
+        assertThat(filter.isWhitelisted(toLogEntry("user2"))).isFalse();
     }
 
     private static AuditEntry toLogEntry(String user)

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/role/TestAuditFilterAuthorizer.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/role/TestAuditFilterAuthorizer.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.filter.role;
+
+import java.util.List;
+
+import com.google.common.collect.Sets;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ericsson.bss.cassandra.ecaudit.auth.AuditAuthorizer;
+import com.ericsson.bss.cassandra.ecaudit.test.mode.ClientInitializer;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.apache.cassandra.auth.AuthenticatedUser;
+import org.apache.cassandra.auth.DataResource;
+import org.apache.cassandra.auth.IAuthorizer;
+import org.apache.cassandra.auth.IResource;
+import org.apache.cassandra.auth.Permission;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(JUnitParamsRunner.class)
+public class TestAuditFilterAuthorizer
+{
+    private static final String AUTH_USER = "auth_user";
+    private static final String UNAUTH_USER = "unauth_user";
+    private static final IResource RESOURCE_DATA = DataResource.fromName("data");
+    private static final IResource RESOURCE_KEYSPACE = DataResource.fromName("data/ks");
+    private static final IResource RESOURCE_TABLE = DataResource.fromName("data/ks/tbl");
+    private static final AuditFilterAuthorizer AUTHORIZER = new AuditFilterAuthorizer();
+
+    @BeforeClass
+    public static void beforeAll()
+    {
+        ClientInitializer.beforeClass();
+
+        AuthenticatedUser user = new AuthenticatedUser(AUTH_USER);
+        IAuthorizer authorizerMock = mock(IAuthorizer.class);
+        when(authorizerMock.authorize(user, RESOURCE_TABLE)).thenReturn(Sets.newHashSet(Permission.SELECT, Permission.MODIFY));
+        when(authorizerMock.authorize(user, RESOURCE_KEYSPACE)).thenReturn(Sets.newHashSet(Permission.CREATE));
+        AUTHORIZER.setAuthorizer(authorizerMock);
+    }
+
+    @AfterClass
+    public static void afterAll()
+    {
+        ClientInitializer.afterClass();
+    }
+
+    @Test
+    public void testGetAuthorizer()
+    {
+        assertThat(AUTHORIZER.getAuthorizer())
+            .isInstanceOf(IAuthorizer.class)
+            .isNotInstanceOf(AuditAuthorizer.class);
+    }
+
+    @SuppressWarnings("unused")
+    private Object[] parametersForTestOperationAuthorization()
+    {
+        return new Object[]{
+            new Object[]{ Permission.SELECT, AUTH_USER, asList(RESOURCE_TABLE), true },
+            new Object[]{ Permission.MODIFY, AUTH_USER, asList(RESOURCE_TABLE), true },
+            new Object[]{ Permission.ALTER, AUTH_USER, asList(RESOURCE_TABLE), false },
+            new Object[]{ Permission.SELECT, AUTH_USER, asList(RESOURCE_KEYSPACE), false },
+            new Object[]{ Permission.CREATE, AUTH_USER, asList(RESOURCE_KEYSPACE), true },
+            new Object[]{ Permission.MODIFY, AUTH_USER, asList(RESOURCE_DATA), false },
+            new Object[]{ Permission.SELECT, UNAUTH_USER, asList(RESOURCE_TABLE), false },
+            new Object[]{ Permission.CREATE, AUTH_USER, asList(RESOURCE_DATA, RESOURCE_KEYSPACE, RESOURCE_TABLE), true },
+            new Object[]{ Permission.DESCRIBE, AUTH_USER, asList(RESOURCE_DATA, RESOURCE_KEYSPACE, RESOURCE_TABLE), false },
+        };
+    }
+
+    @Test
+    @Parameters
+    public void testOperationAuthorization(Permission operation, String user, List<IResource> resources, boolean expectedAuthorized)
+    {
+        assertThat(AUTHORIZER.isOperationAuthorizedForUser(operation, user, resources)).isEqualTo(expectedAuthorized);
+    }
+}

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/role/TestRoleAuditFilter.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/role/TestRoleAuditFilter.java
@@ -93,7 +93,7 @@ public class TestRoleAuditFilter
         givenRolesOfRequest("primary", "inherited");
         AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"));
 
-        assertThat(filter.isFiltered(auditEntry)).isTrue();
+        assertThat(filter.isWhitelisted(auditEntry)).isTrue();
     }
 
     @Test
@@ -103,7 +103,7 @@ public class TestRoleAuditFilter
         givenRolesOfRequest("primary", "inherited");
         AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"));
 
-        assertThat(filter.isFiltered(auditEntry)).isTrue();
+        assertThat(filter.isWhitelisted(auditEntry)).isTrue();
     }
 
     @Test
@@ -113,7 +113,7 @@ public class TestRoleAuditFilter
         givenRolesOfRequest("primary", "inherited");
         AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"));
 
-        assertThat(filter.isFiltered(auditEntry)).isTrue();
+        assertThat(filter.isWhitelisted(auditEntry)).isTrue();
     }
 
     @Test
@@ -123,7 +123,7 @@ public class TestRoleAuditFilter
         givenRolesOfRequest("primary", "inherited");
         AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.MODIFY), DataResource.fromName("data/ks/tbl"));
 
-        assertThat(filter.isFiltered(auditEntry)).isTrue();
+        assertThat(filter.isWhitelisted(auditEntry)).isTrue();
     }
 
     @Test
@@ -134,7 +134,7 @@ public class TestRoleAuditFilter
         givenRolesOfRequest("primary", "inherited");
         AuditEntry auditEntry = givenAuditEntry(Sets.newHashSet(Permission.SELECT, Permission.MODIFY), DataResource.fromName("data/ks/tbl"));
 
-        assertThat(filter.isFiltered(auditEntry)).isTrue();
+        assertThat(filter.isWhitelisted(auditEntry)).isTrue();
     }
 
     @Test
@@ -145,7 +145,7 @@ public class TestRoleAuditFilter
         givenRolesOfRequest("primary", "inherited");
         AuditEntry auditEntry = givenAuditEntry(Sets.newHashSet(Permission.SELECT, Permission.MODIFY), DataResource.fromName("data/ks/tbl"));
 
-        assertThat(filter.isFiltered(auditEntry)).isTrue();
+        assertThat(filter.isWhitelisted(auditEntry)).isTrue();
     }
 
     @Test
@@ -155,7 +155,7 @@ public class TestRoleAuditFilter
         givenRolesOfRequest("primary", "inherited");
         AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/other_tbl"));
 
-        assertThat(filter.isFiltered(auditEntry)).isFalse();
+        assertThat(filter.isWhitelisted(auditEntry)).isFalse();
     }
 
     @Test
@@ -165,7 +165,7 @@ public class TestRoleAuditFilter
         givenRolesOfRequest("primary", "inherited");
         AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"));
 
-        assertThat(filter.isFiltered(auditEntry)).isTrue();
+        assertThat(filter.isWhitelisted(auditEntry)).isTrue();
     }
 
     @Test
@@ -175,7 +175,7 @@ public class TestRoleAuditFilter
         givenRolesOfRequest("primary", "inherited");
         AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.EXECUTE), ConnectionResource.root());
 
-        assertThat(filter.isFiltered(auditEntry)).isTrue();
+        assertThat(filter.isWhitelisted(auditEntry)).isTrue();
     }
 
     @Test
@@ -184,7 +184,7 @@ public class TestRoleAuditFilter
         givenRolesOfRequest("primary", "inherited");
         AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.EXECUTE), ConnectionResource.root());
 
-        assertThat(filter.isFiltered(auditEntry)).isFalse();
+        assertThat(filter.isWhitelisted(auditEntry)).isFalse();
     }
 
     @Test
@@ -193,7 +193,7 @@ public class TestRoleAuditFilter
         givenRolesOfRequest("primary", "inherited");
         AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.MODIFY), DataResource.fromName("data/ks/tbl"));
 
-        assertThat(filter.isFiltered(auditEntry)).isFalse();
+        assertThat(filter.isWhitelisted(auditEntry)).isFalse();
     }
 
     @Test
@@ -204,7 +204,7 @@ public class TestRoleAuditFilter
         AuditEntry auditEntry = givenAuditEntry(Collections.singleton(Permission.SELECT), DataResource.fromName("data/ks/tbl"));
 
         assertThatExceptionOfType(CassandraException.class)
-        .isThrownBy(() -> filter.isFiltered(auditEntry));
+        .isThrownBy(() -> filter.isWhitelisted(auditEntry));
     }
 
     private void givenRolesOfRequest(String... roleNames)

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/role/TestRoleWhitelistChecker.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/role/TestRoleWhitelistChecker.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.filter.role;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ericsson.bss.cassandra.ecaudit.auth.GrantResource;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.apache.cassandra.auth.DataResource;
+import org.apache.cassandra.auth.IResource;
+import org.apache.cassandra.auth.Permission;
+import org.apache.cassandra.auth.Resources;
+import org.apache.cassandra.auth.RoleResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnitParamsRunner.class)
+public class TestRoleWhitelistChecker
+{
+    private static final Map<IResource, Set<Permission>> WHITELIST = ImmutableMap.of(
+        DataResource.fromName("data/ks"), ImmutableSet.of(Permission.SELECT),
+        DataResource.fromName("data/ks/tbl"), ImmutableSet.of(Permission.CREATE, Permission.MODIFY),
+        GrantResource.fromResource(DataResource.fromName("data")), ImmutableSet.of(Permission.DESCRIBE),
+        GrantResource.fromResource(RoleResource.fromName("roles/kalle")), ImmutableSet.of(Permission.ALTER),
+        GrantResource.root(), ImmutableSet.of(Permission.DROP)
+    );
+
+    @SuppressWarnings("unused")
+    private Object[] parametersForTestWhitelistChecker()
+    {
+        return new Object[]{
+            new Object[]{ Permission.SELECT, DataResource.fromName("data/ks"), true, false },       // keyspace whitelisted
+            new Object[]{ Permission.SELECT, DataResource.fromName("data/ks/tbl"), true, false },   // table (through keyspace) whitelisted
+            new Object[]{ Permission.CREATE, DataResource.fromName("data/ks/tbl"), true, false },   // table whitelisted
+            new Object[]{ Permission.CREATE, DataResource.fromName("data/ks"), false, false },      // CREATE not whitelisted
+            new Object[]{ Permission.DESCRIBE, DataResource.fromName("data/ks/tbl"), false, true }, // table (through data) grant whitelisted
+            new Object[]{ Permission.ALTER, RoleResource.fromName("roles/kalle"), false, true },    // role (kalle) grant whitelisted
+            new Object[]{ Permission.DROP, RoleResource.fromName("roles"), false, true },           // DROP grant whitelisted (through root-level grant)
+        };
+    }
+
+    @Test
+    @Parameters
+    public void testWhitelistChecker(Permission operation, IResource resource, boolean expectedWhitelisted, boolean expectedGrantWhitelisted)
+    {
+        List<? extends IResource> resourceChain = Resources.chain(resource);
+
+        RoleWhitelistChecker checker = new RoleWhitelistChecker(operation, resourceChain, WHITELIST);
+
+        assertThat(checker.isWhitelisted()).isEqualTo(expectedWhitelisted);
+        assertThat(checker.isGrantWhitelisted()).isEqualTo(expectedGrantWhitelisted);
+    }
+}

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/yaml/TestYamlAuditFilter.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/yaml/TestYamlAuditFilter.java
@@ -54,7 +54,7 @@ public class TestYamlAuditFilter
 
         List<String> users = new ArrayList<>(Arrays.asList("foo", "User1", "bar", "User2", "fnord", "another"));
 
-        assertThat(users.stream().map(TestYamlAuditFilter::toLogEntry).map(filter::isFiltered)
+        assertThat(users.stream().map(TestYamlAuditFilter::toLogEntry).map(filter::isWhitelisted)
                 .collect(Collectors.toList()))
                         .containsExactly(false, true, false, true, false, false);
     }
@@ -69,7 +69,7 @@ public class TestYamlAuditFilter
         assertThat(users.stream()
                 .map(TestYamlAuditFilter::toLogEntry)
                 .map(TestYamlAuditFilter::asLoginEntry)
-                .map(filter::isFiltered)
+                .map(filter::isWhitelisted)
                 .collect(Collectors.toList()))
                 .containsOnly(false);
     }

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/yamlandrole/TestYamlAndRoleAuditFilter.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/yamlandrole/TestYamlAndRoleAuditFilter.java
@@ -62,34 +62,34 @@ public class TestYamlAndRoleAuditFilter
     @Test
     public void testFilteredByBothResultInFiltered()
     {
-        when(yamlFilter.isFiltered(eq(auditEntry))).thenReturn(true);
+        when(yamlFilter.isWhitelisted(eq(auditEntry))).thenReturn(true);
 
-        assertThat(combinedFilter.isFiltered(auditEntry)).isEqualTo(true);
+        assertThat(combinedFilter.isWhitelisted(auditEntry)).isEqualTo(true);
     }
 
     @Test
     public void testFilteredByYamlOnlyResultInFiltered()
     {
-        when(yamlFilter.isFiltered(eq(auditEntry))).thenReturn(true);
+        when(yamlFilter.isWhitelisted(eq(auditEntry))).thenReturn(true);
 
-        assertThat(combinedFilter.isFiltered(auditEntry)).isEqualTo(true);
+        assertThat(combinedFilter.isWhitelisted(auditEntry)).isEqualTo(true);
     }
 
     @Test
     public void testFilteredByRoleOnlyResultInFiltered()
     {
-        when(yamlFilter.isFiltered(eq(auditEntry))).thenReturn(false);
-        when(roleFilter.isFiltered(eq(auditEntry))).thenReturn(true);
+        when(yamlFilter.isWhitelisted(eq(auditEntry))).thenReturn(false);
+        when(roleFilter.isWhitelisted(eq(auditEntry))).thenReturn(true);
 
-        assertThat(combinedFilter.isFiltered(auditEntry)).isEqualTo(true);
+        assertThat(combinedFilter.isWhitelisted(auditEntry)).isEqualTo(true);
     }
 
     @Test
     public void testFilteredByNoneResultInNotFiltered()
     {
-        when(yamlFilter.isFiltered(eq(auditEntry))).thenReturn(false);
-        when(roleFilter.isFiltered(eq(auditEntry))).thenReturn(false);
+        when(yamlFilter.isWhitelisted(eq(auditEntry))).thenReturn(false);
+        when(roleFilter.isWhitelisted(eq(auditEntry))).thenReturn(false);
 
-        assertThat(combinedFilter.isFiltered(auditEntry)).isEqualTo(false);
+        assertThat(combinedFilter.isWhitelisted(auditEntry)).isEqualTo(false);
     }
 }

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/utils/TestAuthenticatedUserUtil.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/utils/TestAuthenticatedUserUtil.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Telefonaktiebolaget LM Ericsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ericsson.bss.cassandra.ecaudit.utils;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+
+import com.ericsson.bss.cassandra.ecaudit.test.mode.ClientInitializer;
+import org.apache.cassandra.auth.AuthenticatedUser;
+import org.apache.cassandra.auth.RoleResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestAuthenticatedUserUtil
+{
+    @BeforeClass
+    public static void beforeAll()
+    {
+        ClientInitializer.beforeClass();
+    }
+
+    @AfterClass
+    public static void afterAll()
+    {
+        ClientInitializer.afterClass();
+    }
+
+    @Test
+    public void testSuper()
+    {
+        AuthenticatedUser user = AuthenticatedUserUtil.createFromString("system");
+        assertThat(user).isSameAs(AuthenticatedUser.SYSTEM_USER);
+        assertThat(user.isSystem()).isTrue();
+    }
+
+    @Test
+    public void testAnonymous()
+    {
+        AuthenticatedUser user = AuthenticatedUserUtil.createFromString("anonymous");
+        assertThat(user).isSameAs(AuthenticatedUser.ANONYMOUS_USER);
+        assertThat(user.isAnonymous()).isTrue();
+    }
+
+    @Test
+    public void testCustomUser()
+    {
+        AuthenticatedUser user = AuthenticatedUserUtil.createFromString("Bob");
+        assertThat(user.getName()).isEqualTo("Bob");
+        assertThat(user.getPrimaryRole()).isEqualTo(RoleResource.role("Bob"));
+    }
+}

--- a/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITDataAudit.java
+++ b/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITDataAudit.java
@@ -24,8 +24,11 @@ import org.junit.runner.RunWith;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.UnauthorizedException;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @RunWith(JUnitParamsRunner.class)
 public class ITDataAudit
@@ -37,15 +40,23 @@ public class ITDataAudit
     private static Cluster testCluster;
     private static Session testSession;
 
+    private static String basicUsername;
+    private static Cluster basicCluster;
+    private static Session basicSession;
+
     @BeforeClass
     public static void beforeClass()
     {
         ccf.setup();
         testUsername = ccf.givenUniqueSuperuserWithMinimalWhitelist();
-        testCluster = ccf.createCluster(testUsername, "secret");
+        testCluster = ccf.createCluster(testUsername);
         testSession = testCluster.connect();
 
-        ccf.givenUser(GRANTEE);
+        basicUsername = ccf.givenUniqueBasicUserWithMinimalWhitelist();
+        basicCluster = ccf.createCluster(basicUsername);
+        basicSession = basicCluster.connect();
+
+        ccf.givenBasicUser(GRANTEE);
     }
 
     @Before
@@ -59,11 +70,14 @@ public class ITDataAudit
     {
         ccf.after();
         ccf.resetTestUserWithMinimalWhitelist(testUsername);
+        ccf.resetTestUserWithMinimalWhitelist(basicUsername);
     }
 
     @AfterClass
     public static void afterClass()
     {
+        basicSession.close();
+        basicCluster.close();
         testSession.close();
         testCluster.close();
         ccf.tearDown();
@@ -73,10 +87,10 @@ public class ITDataAudit
     private Object[] parametersForSimpleStatements()
     {
         return new Object[]{
-            new Object[]{ "CREATE KEYSPACE dataks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1} AND DURABLE_WRITES = false", "create", "data/dataks" },
-            new Object[]{ "CREATE TABLE dataks.tbl (key int PRIMARY KEY, value text)", "create", "data/dataks" },
-            new Object[]{ "CREATE INDEX idx ON dataks.tbl (value)", "alter", "data/dataks/tbl" },
-            new Object[]{ "CREATE TYPE dataks.tp (data1 int, data2 int)", "create", "data/dataks" },
+            new Object[]{ "CREATE KEYSPACE IF NOT EXISTS dataks WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1} AND DURABLE_WRITES = false", "create", "data/dataks" },
+            new Object[]{ "CREATE TABLE IF NOT EXISTS dataks.tbl (key int PRIMARY KEY, value text)", "create", "data/dataks" },
+            new Object[]{ "CREATE INDEX IF NOT EXISTS idx ON dataks.tbl (value)", "alter", "data/dataks/tbl" },
+            new Object[]{ "CREATE TYPE IF NOT EXISTS dataks.tp (data1 int, data2 int)", "create", "data/dataks" },
             new Object[]{ "SELECT * FROM dataks.tbl WHERE key = 12", "select", "data/dataks/tbl" },
             new Object[]{ "INSERT INTO dataks.tbl (key, value) VALUES (45, 'hepp')", "modify", "data/dataks/tbl" },
             new Object[]{ "UPDATE dataks.tbl SET value = 'hepp' WHERE key = 99", "modify", "data/dataks/tbl" },
@@ -108,5 +122,50 @@ public class ITDataAudit
         ccf.givenRoleIsWhitelistedForOperationOnResource(testUsername, operation, resource);
         testSession.execute(statement);
         ccf.thenAuditLogContainNothingForUser();
+    }
+
+    @Test
+    @Parameters(method = "parametersForSimpleStatements")
+    public void simpleStatementIsGrantWhitelisted(String statement, String operation, String resource)
+    {
+        ccf.givenRoleIsWhitelistedForOperationOnResource(testUsername, operation, "grants/" + resource);
+        testSession.execute(statement);
+        ccf.thenAuditLogContainNothingForUser();
+    }
+
+    @Test
+    @Parameters(method = "parametersForSimpleStatements")
+    @SuppressWarnings("unused")
+    public void simpleStatementIsGrantWhitelistedUsingTopLevelGrant(String statement, String operation, String resource)
+    {
+        ccf.givenRoleIsWhitelistedForOperationOnResource(testUsername, operation, "grants");
+        testSession.execute(statement);
+        ccf.thenAuditLogContainNothingForUser();
+    }
+
+    @Test
+    @Parameters(method = "parametersForSimpleStatements")
+    public void simpleStatementIsLoggedWhenGrantWhitelistUnauthorized(String statement, String operation, String resource)
+    {
+        // Add the below resources to make sure the test(s) fails due to Authorization failure
+        ccf.givenKeyspace("dataks");
+        ccf.givenTable("dataks.tbl");
+        givenIndex("dataks.tbl", "idx");
+        givenType("dataks.tp");
+
+        ccf.givenRoleIsWhitelistedForOperationOnResource(basicUsername, operation, "grants/" + resource);
+        assertThatExceptionOfType(UnauthorizedException.class)
+            .isThrownBy(() -> basicSession.execute(statement));
+        ccf.thenAuditLogContainsFailedEntriesForUser(statement, basicUsername);
+    }
+
+    private void givenIndex(String table, String index)
+    {
+        ccf.givenStatementExecutedAsSuperuserWithoutAudit("CREATE INDEX IF NOT EXISTS " + index + " ON " + table + " (value)");
+    }
+
+    private void givenType(String type)
+    {
+        ccf.givenStatementExecutedAsSuperuserWithoutAudit("CREATE TYPE IF NOT EXISTS " + type + "(data1 int, data2 int)");
     }
 }

--- a/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITRolesAudit.java
+++ b/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITRolesAudit.java
@@ -24,28 +24,40 @@ import org.junit.runner.RunWith;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.UnauthorizedException;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @RunWith(JUnitParamsRunner.class)
 public class ITRolesAudit
 {
     private static CassandraClusterFacade ccf = new CassandraClusterFacade();
+    private static final String USER = "role_user";
     private static final String ROLE = "role_role";
 
     private static String testUsername;
     private static Cluster testCluster;
     private static Session testSession;
 
+    private static String basicUsername;
+    private static Cluster basicCluster;
+    private static Session basicSession;
+
     @BeforeClass
     public static void beforeClass()
     {
         ccf.setup();
         testUsername = ccf.givenUniqueSuperuserWithMinimalWhitelist();
-        testCluster = ccf.createCluster(testUsername, "secret");
+        testCluster = ccf.createCluster(testUsername);
         testSession = testCluster.connect();
 
-        ccf.givenUser(ROLE);
+        basicUsername = ccf.givenUniqueBasicUserWithMinimalWhitelist();
+        basicCluster = ccf.createCluster(basicUsername);
+        basicSession = basicCluster.connect();
+
+        ccf.givenBasicUser(ROLE);
     }
 
     @Before
@@ -59,11 +71,14 @@ public class ITRolesAudit
     {
         ccf.after();
         ccf.resetTestUserWithMinimalWhitelist(testUsername);
+        ccf.resetTestUserWithMinimalWhitelist(basicUsername);
     }
 
     @AfterClass
     public static void afterClass()
     {
+        basicSession.close();
+        basicCluster.close();
         testSession.close();
         testCluster.close();
         ccf.tearDown();
@@ -73,12 +88,12 @@ public class ITRolesAudit
     private Object[] parametersForRoleStatements()
     {
         return new Object[]{
-            new Object[]{ "CREATE ROLE role_user WITH PASSWORD = 'secret' AND LOGIN = true AND SUPERUSER = true", "create", "roles" },
-            new Object[]{ "ALTER ROLE role_user WITH LOGIN = false", "alter", "roles/role_user" },
-            new Object[]{ "GRANT " + ROLE + " TO role_user", "authorize", "roles/" + ROLE },
-            new Object[]{ "REVOKE " + ROLE + " FROM role_user", "authorize", "roles/" + ROLE},
-            new Object[]{ "LIST ROLES OF role_user", "describe", "roles" },
-            new Object[]{ "DROP ROLE role_user", "drop", "roles/role_user" },
+            new Object[]{ "CREATE ROLE IF NOT EXISTS " + USER + " WITH PASSWORD = 'secret' AND LOGIN = true AND SUPERUSER = true", "create", "roles" },
+            new Object[]{ "ALTER ROLE " + USER + " WITH LOGIN = false", "alter", "roles/" + USER },
+            new Object[]{ "GRANT " + ROLE + " TO " + USER, "authorize", "roles/" + ROLE },
+            new Object[]{ "REVOKE " + ROLE + " FROM " + USER, "authorize", "roles/" + ROLE},
+            new Object[]{ "LIST ROLES OF " + USER, "describe", "roles" },
+            new Object[]{ "DROP ROLE " + USER, "drop", "roles/" + USER },
         };
     }
 
@@ -99,4 +114,36 @@ public class ITRolesAudit
         testSession.execute(statement);
         ccf.thenAuditLogContainNothingForUser();
     }
+
+    @Test
+    @Parameters(method = "parametersForRoleStatements")
+    public void statementIsGrantWhitelisted(String statement, String operation, String resource)
+    {
+        ccf.givenRoleIsWhitelistedForOperationOnResource(testUsername, operation, "grants/" + resource);
+        testSession.execute(statement);
+        ccf.thenAuditLogContainNothingForUser();
+    }
+
+    @Test
+    @Parameters(method = "parametersForRoleStatements")
+    @SuppressWarnings("unused")
+    public void statementIsGrantWhitelistedUsingTopLevelGrant(String statement, String operation, String resource)
+    {
+        ccf.givenRoleIsWhitelistedForOperationOnResource(testUsername, operation, "grants");
+        testSession.execute(statement);
+        ccf.thenAuditLogContainNothingForUser();
+    }
+
+    @Test
+    @Parameters(method = "parametersForRoleStatements")
+    public void statementIsLoggedWhenGrantWhitelistUnauthorized(String statement, String operation, String resource)
+    {
+        ccf.givenBasicUser(USER);
+
+        ccf.givenRoleIsWhitelistedForOperationOnResource(basicUsername, operation, "grants/" + resource);
+        assertThatExceptionOfType(UnauthorizedException.class)
+            .isThrownBy(() -> basicSession.execute(statement));
+        ccf.thenAuditLogContainsFailedEntriesForUser(statement, basicUsername);
+    }
+
 }

--- a/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITVerifyWhitelistManagement.java
+++ b/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITVerifyWhitelistManagement.java
@@ -205,6 +205,15 @@ public class ITVerifyWhitelistManagement
     }
 
     @Test
+    public void testAuthorizedUserCanGrantWhitelistToHimself()
+    {
+        authorizedSession.execute(new SimpleStatement(
+        "ALTER ROLE authorized_user WITH OPTIONS = { 'grant_audit_whitelist_for_all' : 'data' }"));
+
+        assertRoleOperations("authorized_user", "data", asList("CREATE", "ALTER", "DROP", "SELECT", "MODIFY", "AUTHORIZE"));
+    }
+
+    @Test
     public void testAuthorizedUserCanGrantWhitelistToOther()
     {
         authorizedSession.execute(new SimpleStatement(
@@ -383,6 +392,6 @@ public class ITVerifyWhitelistManagement
 
         String operationsString = optionsMap.get(expectedKey);
         List<String> operations = Splitter.on(",").trimResults().splitToList(operationsString);
-        assertThat(operations).containsOnlyElementsOf(expectedOperations);
+        assertThat(operations).hasSameElementsAs(expectedOperations);
     }
 }

--- a/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITVerifyWhitelistManagement.java
+++ b/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITVerifyWhitelistManagement.java
@@ -17,6 +17,7 @@ package com.ericsson.bss.cassandra.ecaudit.integration.standard;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Splitter;
 import org.junit.After;
@@ -33,6 +34,7 @@ import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.exceptions.UnauthorizedException;
 import com.ericsson.bss.cassandra.ecaudit.test.daemon.CassandraDaemonForAuditTest;
 import net.jcip.annotations.NotThreadSafe;
+import org.apache.cassandra.auth.Permission;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.Arrays.asList;
@@ -185,6 +187,17 @@ public class ITVerifyWhitelistManagement
     }
 
     @Test(expected = UnauthorizedException.class)
+    public void testOrdinaryUserCannotGrantWhitelistHimself()
+    {
+        try (Cluster privateCluster = cdt.createCluster("ordinary_user", "secret");
+                Session privateSession = privateCluster.connect())
+        {
+            privateSession.execute(new SimpleStatement(
+                    "ALTER ROLE ordinary_user WITH OPTIONS = { 'grant_audit_whitelist_for_all' : 'grants/data' }"));
+        }
+    }
+
+    @Test(expected = UnauthorizedException.class)
     public void testCreateUserCannotWhitelistUser()
     {
         try (Cluster privateCluster = cdt.createCluster("create_user", "secret");
@@ -220,6 +233,24 @@ public class ITVerifyWhitelistManagement
         "ALTER ROLE other_user WITH OPTIONS = { 'grant_audit_whitelist_for_all' : 'data' }"));
 
         assertRoleOperations("other_user", "data", asList("CREATE", "ALTER", "DROP", "SELECT", "MODIFY", "AUTHORIZE"));
+    }
+
+    @Test
+    public void testAuthorizedUserCanGrantPermissionDerivedWhitelistToHimself()
+    {
+        authorizedSession.execute(new SimpleStatement(
+        "ALTER ROLE authorized_user WITH OPTIONS = { 'grant_audit_whitelist_for_all' : 'grants/data' }"));
+
+        assertRoleOperations("authorized_user", "grants/data", asList("CREATE", "ALTER", "DROP", "SELECT", "MODIFY", "AUTHORIZE"));
+    }
+
+    @Test
+    public void testAuthorizedUserCanGrantPermissionDerivedWhitelistToOthers()
+    {
+        authorizedSession.execute(new SimpleStatement(
+        "ALTER ROLE other_user WITH OPTIONS = { 'grant_audit_whitelist_for_all' : 'grants/data' }"));
+
+        assertRoleOperations("other_user", "grants/data", asList("CREATE", "ALTER", "DROP", "SELECT", "MODIFY", "AUTHORIZE"));
     }
 
     @Test(expected = UnauthorizedException.class)
@@ -322,6 +353,34 @@ public class ITVerifyWhitelistManagement
         given_temporary_user(superSession);
         superSession.execute(new SimpleStatement(
         "ALTER ROLE temporary_user WITH OPTIONS = { 'grant_audit_whitelist_for_all' : 'connections/native' }"));
+    }
+
+    @Test
+    public void testSuperUserCanWhitelistOnGrant()
+    {
+        given_temporary_user(superSession);
+        superSession.execute(new SimpleStatement(
+        "ALTER ROLE temporary_user WITH OPTIONS = { 'grant_audit_whitelist_for_all' : 'grants' }"));
+
+        List<String> allPermissions = Permission.ALL.stream().map(Enum::name).collect(Collectors.toList());
+        assertRoleOperations("temporary_user", "grants", allPermissions);
+    }
+
+    @Test
+    public void testSuperUserCanWhitelistOnTableDataGrant()
+    {
+        given_temporary_user(superSession);
+        superSession.execute(new SimpleStatement(
+        "ALTER ROLE temporary_user WITH OPTIONS = { 'grant_audit_whitelist_for_all' : 'grants/data/ks/tb' }"));
+        assertRoleOperations("temporary_user", "grants/data/ks/tb", asList("ALTER", "DROP", "SELECT", "MODIFY", "AUTHORIZE"));
+    }
+
+    @Test (expected = InvalidQueryException.class)
+    public void testSuperUserCanNotWhitelistOnGrantWithInvalidResource()
+    {
+        given_temporary_user(superSession);
+        superSession.execute(new SimpleStatement(
+        "ALTER ROLE temporary_user WITH OPTIONS = { 'grant_audit_whitelist_for_all' : 'grants/non_existing_resource' }"));
     }
 
     @Test


### PR DESCRIPTION
Grants-based or Permission Derived whitelists is a convenient way to
configure whitelisting, without having to configure too much details.

The following statement:
cqlsh> ALTER ROLE kalle WITH OPTIONS = { 'GRANT AUDIT WHITELIST FOR MODIFY' : 'grants/data' };

Will whitelist the "kalle"-user on MODIFY operations to all
keyspaces/tables he has permissions to modify.

If he tries to modify a table where he lacks permission, not only will
the operation be unauthorized, it will also be audit logged.