### PR TITLE
Add support for prepared batch statements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## Version 2.6.0
+* Support prepared batch statements - #164
 * Support pure query logger deployment without authentication/authorization - #77
 
 ## Version 2.5.0

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/factory/AuditEntryBuilderFactory.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/factory/AuditEntryBuilderFactory.java
@@ -92,7 +92,6 @@ public class AuditEntryBuilderFactory
     private static final Set<Permission> DROP_PERMISSIONS = ImmutableSet.of(Permission.DROP);
     private static final Set<Permission> DESCRIBE_PERMISSIONS = ImmutableSet.of(Permission.DESCRIBE);
     private static final Set<Permission> AUTHORIZE_PERMISSIONS = ImmutableSet.of(Permission.AUTHORIZE);
-    private static final String UNEXPECTED_BATCH_STATEMENT = "Unexpected BatchStatement when mapping single query for audit";
 
     private final StatementResourceAdapter statementResourceAdapter = new StatementResourceAdapter();
 
@@ -180,11 +179,9 @@ public class AuditEntryBuilderFactory
         {
             return createAuthorizationEntryBuilder((AuthorizationStatement) parsedStatement);
         }
-
         if (parsedStatement instanceof BatchStatement.Parsed)
         {
-            LOG.error(UNEXPECTED_BATCH_STATEMENT);
-            throw new CassandraAuditException(UNEXPECTED_BATCH_STATEMENT);
+            return createBatchEntryBuilder();
         }
 
         LOG.warn("Detected unrecognized CQLStatement in audit mapping");

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/factory/AuditEntryBuilderFactory.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/factory/AuditEntryBuilderFactory.java
@@ -222,11 +222,9 @@ public class AuditEntryBuilderFactory
         {
             return createAuthorizationEntryBuilder((AuthorizationStatement) statement);
         }
-
         if (statement instanceof BatchStatement)
         {
-            LOG.error("Unexpected BatchStatement when mapping singe query for audit");
-            throw new CassandraAuditException("Unexpected BatchStatement when mapping singe query for audit");
+            return createBatchEntryBuilder();
         }
 
         LOG.warn("Detected unrecognized CQLStatement in audit mapping");
@@ -252,8 +250,8 @@ public class AuditEntryBuilderFactory
             // TODO: We should be able to fix this
             // This would be the result of a query towards a non-existing resource in a batch statement
             // But right now we don't get here since batch statements fail pre-processing
-            LOG.error("Failed to parse and prepare BatchStatement when mapping singe query for audit", e);
-            throw new CassandraAuditException("Failed to parse and prepare BatchStatement when mapping singe query for audit", e);
+            LOG.error("Failed to parse and prepare BatchStatement when mapping single query for audit", e);
+            throw new CassandraAuditException("Failed to parse and prepare BatchStatement when mapping single query for audit", e);
         }
 
         return updateBatchEntryBuilder(builder, (ModificationStatement) statement);

--- a/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITVerifyThreadedAudit.java
+++ b/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITVerifyThreadedAudit.java
@@ -144,6 +144,11 @@ public class ITVerifyThreadedAudit
 
         for (int i = 0; i < USER_COUNT; i++)
         {
+            jobResults.add(executorService.submit(new BatchStatementClient("user" + i)));
+        }
+
+        for (int i = 0; i < USER_COUNT; i++)
+        {
             jobResults.add(executorService.submit(new PreparedBatchStatementClient("user" + i)));
         }
 
@@ -207,11 +212,11 @@ public class ITVerifyThreadedAudit
         }
     }
 
-    public class PreparedBatchStatementClient implements Callable<List<String>>
+    public class BatchStatementClient implements Callable<List<String>>
     {
         private final String username;
 
-        public PreparedBatchStatementClient(String username)
+        public BatchStatementClient(String username)
         {
             this.username = username;
         }
@@ -249,6 +254,42 @@ public class ITVerifyThreadedAudit
                 }
 
                 return expectedBatchAttemptFragmentsAsUser(expectedStatements, username);
+            }
+        }
+    }
+
+    public class PreparedBatchStatementClient implements Callable<List<String>>
+    {
+        private final String username;
+
+        public PreparedBatchStatementClient(String username)
+        {
+            this.username = username;
+        }
+
+        @Override
+        public List<String> call()
+        {
+            try (Cluster cluster = cdt.createCluster(username, "secret");
+                 Session session = cluster.connect())
+            {
+                String batch = "BEGIN UNLOGGED BATCH USING TIMESTAMP ? " +
+                               "INSERT INTO ecks.ectbl (partk, clustk, value) VALUES (?, ?, ?); " +
+                               "INSERT INTO ecks.ectbl (partk, clustk, value) VALUES (?, ?, 'static'); " +
+                               "INSERT INTO ecks.ectbl (partk, clustk) VALUES (?, ?); " +
+                               "APPLY BATCH;";
+
+                PreparedStatement preparedBatchStatement = session.prepare(batch);
+
+                List<String> expectedStatements = new ArrayList<>();
+
+                for (int i = 0; i < 10; i++)
+                {
+                    expectedStatements.add(batch + String.format("[1234, %d, '1', 'b1', %d, '3', %d, '5']", 100 + i, 200 + i, 300 + i));
+                    session.execute(preparedBatchStatement.bind(1234L, 100 + i, "1", "b1", 200 + i, "3", 300 + i, "5"));
+                }
+
+                return expectedAttemptsAsUser(expectedStatements, username);
             }
         }
     }


### PR DESCRIPTION
Previous tests assumed normal batches containing prepared statements.

Fixes #164

Tries to align it with log entries from Apache Cassandra 4.0:
```
INFO  [Native-Transport-Requests-1] 2020-04-07 13:39:04,545 FileAuditLogger.java:49 - user:anonymous|host:127.0.0.1:7000|source:/127.0.0.1|port:34212|timestamp:1586259544538|type:BATCH|category:DML|operation:BEGIN UNLOGGED BATCH USING TIMESTAMP ? INSERT INTO ecks.ectbl (partk, clustk, value) VALUES (?, ?, ?); INSERT INTO ecks.ectbl (partk, clustk, value) VALUES (?, ?, 'valid'); APPLY BATCH;
```

Even though it is slightly different compared to the batches currently handled.