### PR TITLE
Extend grant based audit to system tables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.8.0
 * Obfuscate passwords properly - #170
+* Grant based audit doesn't take system resources into consideration - #172
 
 ## Version 2.7.0
 * Build with Cassandra 3.11.10 (only flavor ecaudit_c3.11)

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/role/AuditFilterAuthorizer.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/filter/role/AuditFilterAuthorizer.java
@@ -15,24 +15,47 @@
  */
 package com.ericsson.bss.cassandra.ecaudit.filter.role;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
 
 import com.ericsson.bss.cassandra.ecaudit.auth.AuditAuthorizer;
 import com.ericsson.bss.cassandra.ecaudit.utils.AuthenticatedUserUtil;
 import org.apache.cassandra.auth.AuthenticatedUser;
+import org.apache.cassandra.auth.DataResource;
 import org.apache.cassandra.auth.IAuthorizer;
 import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.Permission;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.db.SystemKeyspace;
+import org.apache.cassandra.schema.LegacySchemaTables;
 
 public class AuditFilterAuthorizer
 {
+    // Matching Apache Cassandra operations defined in ClientState
+    private static final Set<IResource> READABLE_SYSTEM_RESOURCES = new HashSet<>();
+
+    static
+    {
+        for (String cf : Iterables.concat(Arrays.asList(SystemKeyspace.LOCAL, SystemKeyspace.PEERS), LegacySchemaTables.ALL))
+        {
+            READABLE_SYSTEM_RESOURCES.add(DataResource.table(SystemKeyspace.NAME, cf));
+        }
+    }
+
     private IAuthorizer authorizer; // lazy initialization
 
     public boolean isOperationAuthorizedForUser(Permission operation, String user, List<? extends IResource> resourceChain)
     {
+        if (isReadingSystemResource(operation, resourceChain))
+        {
+            return true;
+        }
+
         AuthenticatedUser authUser = AuthenticatedUserUtil.createFromString(user);
         IAuthorizer authorizer = getAuthorizer();
         return resourceChain.stream()
@@ -53,6 +76,16 @@ public class AuditFilterAuthorizer
             resolveAuthorizerSync();
         }
         return authorizer;
+    }
+
+    private static boolean isReadingSystemResource(Permission operation, List<? extends IResource> resourceChain)
+    {
+        if (operation != Permission.SELECT)
+        {
+            return false;
+        }
+
+        return resourceChain.stream().anyMatch(READABLE_SYSTEM_RESOURCES::contains);
     }
 
     private synchronized void resolveAuthorizerSync()

--- a/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITRolesAudit.java
+++ b/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITRolesAudit.java
@@ -37,6 +37,8 @@ public class ITRolesAudit
     private static final String USER = "role_user";
     private static final String ROLE = "role_role";
 
+    private static final String GRANT_BASED_USER = "grant_based_user";
+
     private static String testUsername;
     private static Cluster testCluster;
     private static Session testSession;
@@ -144,6 +146,18 @@ public class ITRolesAudit
         assertThatExceptionOfType(UnauthorizedException.class)
             .isThrownBy(() -> basicSession.execute(statement));
         ccf.thenAuditLogContainsFailedEntriesForUser(statement, basicUsername);
+    }
+
+    @Test
+    public void systemStatementsAreNotLoggedWithGrantBasedAudit()
+    {
+        ccf.givenBasicUser(GRANT_BASED_USER);
+        ccf.givenRoleIsWhitelistedForOperationOnResource(GRANT_BASED_USER, "ALL", "grants/data");
+        try (Cluster cluster = ccf.createCluster(GRANT_BASED_USER); Session session = cluster.connect())
+        {
+            // Do nothing, we just need to connect
+        }
+        ccf.thenAuditLogContainOnlyAuthenticationAttemptsForUser(GRANT_BASED_USER);
     }
 
 }


### PR DESCRIPTION
While connecting the driver will perform select on a few tables
without explicit permission. Since the user is allowed we should
not log these statements when grant based is configured.

Fixes  #172 for C2.2