### PR TITLE
Extend grant based audit to system tables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 2.8.0
 * Obfuscate passwords properly - #170
+* Grant based audit doesn't take system resources into consideration - #172
 
 ## Version 2.7.0
 * Build with Cassandra 3.11.10 (only flavor ecaudit_c3.11)

--- a/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/role/TestAuditFilterAuthorizer.java
+++ b/ecaudit/src/test/java/com/ericsson/bss/cassandra/ecaudit/filter/role/TestAuditFilterAuthorizer.java
@@ -15,8 +15,11 @@
  */
 package com.ericsson.bss.cassandra.ecaudit.filter.role;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,6 +35,7 @@ import org.apache.cassandra.auth.DataResource;
 import org.apache.cassandra.auth.IAuthorizer;
 import org.apache.cassandra.auth.IResource;
 import org.apache.cassandra.auth.Permission;
+import org.apache.cassandra.db.SystemKeyspace;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,6 +51,10 @@ public class TestAuditFilterAuthorizer
     private static final IResource RESOURCE_KEYSPACE = DataResource.fromName("data/ks");
     private static final IResource RESOURCE_TABLE = DataResource.fromName("data/ks/tbl");
     private static final AuditFilterAuthorizer AUTHORIZER = new AuditFilterAuthorizer();
+
+    // From SchemaKeyspace
+    private static final String SCHEMA_KEYSPACE_NAME = "system_schema";
+    private static final ImmutableList<String> ALL_SCHEMA_TABLES = ImmutableList.of("columns", "dropped_columns", "triggers", "types", "functions", "aggregates", "indexes", "tables", "views", "keyspaces");
 
     @BeforeClass
     public static void beforeAll()
@@ -95,5 +103,45 @@ public class TestAuditFilterAuthorizer
     public void testOperationAuthorization(Permission operation, String user, List<IResource> resources, boolean expectedAuthorized)
     {
         assertThat(AUTHORIZER.isOperationAuthorizedForUser(operation, user, resources)).isEqualTo(expectedAuthorized);
+    }
+
+    @SuppressWarnings("unused")
+    private Object[] parametersForTestSystemOperationAuthorization()
+    {
+        List<Object[]> objects = new ArrayList<>();
+        objects.add(new Object[] {toDataResources(SystemKeyspace.NAME, SystemKeyspace.LOCAL)});
+        objects.add(new Object[] {toDataResources(SystemKeyspace.NAME, SystemKeyspace.PEERS)});
+        objects.add(new Object[] {toDataResources(SystemKeyspace.NAME, "peers_v2")});
+
+        for (String table : ALL_SCHEMA_TABLES)
+        {
+            objects.add(new Object[] {toDataResources(SCHEMA_KEYSPACE_NAME, table)});
+        }
+
+        return objects.toArray();
+    }
+
+    @Test
+    @Parameters
+    public void testSystemOperationAuthorization(List<IResource> resources)
+    {
+        // Select on system keyspaces are ok
+        assertThat(AUTHORIZER.isOperationAuthorizedForUser(Permission.SELECT, AUTH_USER, resources)).isEqualTo(true);
+
+        List<Permission> NOT_OK = new ArrayList<>(Permission.ALL);
+        NOT_OK.remove(Permission.SELECT);
+        for (Permission permission : NOT_OK)
+        {
+            assertThat(AUTHORIZER.isOperationAuthorizedForUser(permission, AUTH_USER, resources)).isEqualTo(false);
+        }
+    }
+
+    private static List<DataResource> toDataResources(String keyspace, String table)
+    {
+        return Arrays.asList(
+            DataResource.fromName(String.format("data/%s/%s", keyspace, table)),
+            DataResource.fromName(String.format("data/%s", keyspace)),
+            DataResource.fromName("data")
+        );
     }
 }

--- a/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/CassandraClusterFacade.java
+++ b/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/CassandraClusterFacade.java
@@ -36,6 +36,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -187,6 +188,16 @@ public class CassandraClusterFacade
         List<ILoggingEvent> loggingEvents = loggingEventCaptor.getAllValues();
 
         assertThat(loggingEvents.get(0).getFormattedMessage()).isEqualTo(expectedAuditEntry(auditOperation, username, "ATTEMPT"));
+    }
+
+    void thenAuditLogContainOnlyAuthenticationAttemptsForUser(String username)
+    {
+        ArgumentCaptor<ILoggingEvent> loggingEventCaptor = ArgumentCaptor.forClass(ILoggingEvent.class);
+        verify(mockAuditAppender, atLeastOnce()).doAppend(loggingEventCaptor.capture());
+
+        String authenticationAttempt = expectedAuditEntry("Authentication attempt", username, "ATTEMPT");
+        List<ILoggingEvent> loggingEvents = loggingEventCaptor.getAllValues();
+        assertThat(loggingEvents).extracting(ILoggingEvent::getFormattedMessage).allMatch(event -> event.equals(authenticationAttempt));
     }
 
     void thenAuditLogContainsFailedEntriesForUser(String auditOperation, String username)

--- a/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITRolesAudit.java
+++ b/integration-test-standard/src/test/java/com/ericsson/bss/cassandra/ecaudit/integration/standard/ITRolesAudit.java
@@ -37,6 +37,8 @@ public class ITRolesAudit
     private static final String USER = "role_user";
     private static final String ROLE = "role_role";
 
+    private static final String GRANT_BASED_USER = "grant_based_user";
+
     private static String testUsername;
     private static Cluster testCluster;
     private static Session testSession;
@@ -144,6 +146,18 @@ public class ITRolesAudit
         assertThatExceptionOfType(UnauthorizedException.class)
             .isThrownBy(() -> basicSession.execute(statement));
         ccf.thenAuditLogContainsFailedEntriesForUser(statement, basicUsername);
+    }
+
+    @Test
+    public void systemStatementsAreNotLoggedWithGrantBasedAudit()
+    {
+        ccf.givenBasicUser(GRANT_BASED_USER);
+        ccf.givenRoleIsWhitelistedForOperationOnResource(GRANT_BASED_USER, "ALL", "grants/data");
+        try (Cluster cluster = ccf.createCluster(GRANT_BASED_USER); Session session = cluster.connect())
+        {
+            // Do nothing, we just need to connect
+        }
+        ccf.thenAuditLogContainOnlyAuthenticationAttemptsForUser(GRANT_BASED_USER);
     }
 
 }


### PR DESCRIPTION
While connecting the driver will perform select on a few tables
without explicit permission. Since the user is allowed we should
not log these statements when grant based is configured.

Fixes #172 for C3.0