### PR TITLE
Add support for single line operation in logs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## Version 2.8.0
+* Add single line operation to Sl4j log format
+
 ## Version 2.7.1
 * Obfuscate passwords properly - #170
 * Extend grant based audit to system tables - #172

--- a/conf/audit.yaml
+++ b/conf/audit.yaml
@@ -76,7 +76,8 @@ log_timing_strategy: pre_logging
 # optional parameters are accepted:
 # - log_format   - Format of the audit record sent to SLF4J. Fields can be configured with bash-style parameter
 #                  substitution. Supported parameters are ${CLIENT_IP}, ${CLIENT_PORT}, ${COORDINATOR_IP}, ${USER},
-#                  ${BATCH_ID}, ${STATUS}, ${OPERATION}, ${OPERATION_NAKED}, ${TIMESTAMP}, and ${SUBJECT}.
+#                  ${BATCH_ID}, ${STATUS}, ${OPERATION}, ${OPERATION_NAKED}, ${SINGLE_LINE_OPERATION}, ${TIMESTAMP}
+#                  and ${SUBJECT}.
 # - time_format  - Format of ${TIMESTAMP} field as defined by the Java DateTimeFormatter. By default this field will be
 #                  unformatted and get printed as milliseconds since epoch of 1970-01-01Z.
 # - time_zone    - Time zone of formatted ${TIMESTAMP}, using system default if unspecified.

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/logger/Slf4jAuditLogger.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/logger/Slf4jAuditLogger.java
@@ -100,6 +100,7 @@ public class Slf4jAuditLogger implements AuditLogger
                .put("STATUS", AuditEntry::getStatus)
                .put("OPERATION", entry -> entry.getOperation().getOperationString())
                .put("OPERATION_NAKED", entry -> entry.getOperation().getNakedOperationString())
+               .put("SINGLE_LINE_OPERATION", Slf4jAuditLogger::singleLineStatement)
                .put("TIMESTAMP", getTimeFunction(auditConfig))
                .put("SUBJECT", entry -> entry.getSubject().orElse(null))
                .build();
@@ -127,6 +128,11 @@ public class Slf4jAuditLogger implements AuditLogger
     private static Function<AuditEntry, Object> getFormattedTimestamp(DateTimeFormatter formatter)
     {
         return auditEntry -> formatter.format(Instant.ofEpochMilli(auditEntry.getTimestamp()));
+    }
+
+    private static Object singleLineStatement(AuditEntry auditEntry)
+    {
+        return auditEntry.getOperation().getOperationString().replaceAll("\\r\\n|\\r|\\n", "\\\\n");
     }
 
     @Override


### PR DESCRIPTION
In 3.0+ we can replace the regex with "\\R" instead of "\\r\\n|\\r|\\n".