### PR TITLE
Reprepare statements that are loaded during startup

### DIFF
--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/PreparedAuditOperation.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/PreparedAuditOperation.java
@@ -89,17 +89,24 @@ public class PreparedAuditOperation implements AuditOperation
 
         fullStatement.append('[');
 
-        Queue<ByteBuffer> values = new LinkedList<>(options.getValues());
-        for (ColumnSpecification column : options.getColumnSpecifications())
+        if (options.getValues().isEmpty())
         {
-            ByteBuffer value = values.remove();
-            String valueString = boundValueSuppressor.suppress(column, value)
-                                                     .orElseGet(() -> CqlLiteralFlavorAdapter.toCQLLiteral(value, column));
-            fullStatement.append(valueString).append(", ");
+            fullStatement.append(']');
         }
+        else
+        {
+            Queue<ByteBuffer> values = new LinkedList<>(options.getValues());
+            for (ColumnSpecification column : options.getColumnSpecifications())
+            {
+                ByteBuffer value = values.remove();
+                String valueString = boundValueSuppressor.suppress(column, value)
+                                                         .orElseGet(() -> CqlLiteralFlavorAdapter.toCQLLiteral(value, column));
+                fullStatement.append(valueString).append(", ");
+            }
 
-        fullStatement.setLength(fullStatement.length() - 1);
-        fullStatement.setCharAt(fullStatement.length() - 1, ']');
+            fullStatement.setLength(fullStatement.length() - 1);
+            fullStatement.setCharAt(fullStatement.length() - 1, ']');
+        }
 
         return fullStatement.toString();
     }

--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/handler/AuditQueryHandler.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/handler/AuditQueryHandler.java
@@ -216,6 +216,13 @@ public class AuditQueryHandler implements QueryHandler
             return null; // Return null to client, will trigger a new attempt
         }
 
+        // When prepared statements are cached during startup the raw CQL statement can be missing
+        if ("".equals(prepared.rawCQLStatement))
+        {
+            QueryProcessor.instance.evictPrepared(id);
+            return null; // Return null to client, will trigger a re-prepare
+        }
+
         preparedRawCqlStatements.get().add(prepared.rawCQLStatement);
 
         return prepared;


### PR DESCRIPTION
This does not seem to affect the 3.0 branch as the statements are not [cached without the raw CQL statement during startup](https://github.com/apache/cassandra/blob/cassandra-3.11/src/java/org/apache/cassandra/cql3/QueryProcessor.java#L160).

The patch handles this by requesting the client to prepare the statement again whenever a prepared statement is cached without the raw CQL statement.

Fixes #193