### PR TITLE
Ran into StringIndexOutOfBoundsException with Golang client for non-prepared statements

### DIFF
--- a/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/PreparedAuditOperation.java
+++ b/ecaudit/src/main/java/com/ericsson/bss/cassandra/ecaudit/entry/PreparedAuditOperation.java
@@ -75,7 +75,7 @@ public class PreparedAuditOperation implements AuditOperation
      */
     private String bindValues()
     {
-        if (!options.hasColumnSpecifications())
+        if (!options.hasColumnSpecifications() || options.getColumnSpecifications().size() == 0)
         {
             return preparedStatement;
         }


### PR DESCRIPTION
We ran into the below exception when executing non-prepared statements with golang client:

java.lang.StringIndexOutOfBoundsException: String index out of range: -1
at java.lang.AbstractStringBuilder.setCharAt(AbstractStringBuilder.java:407)
at java.lang.StringBuilder.setCharAt(StringBuilder.java:76)
at com.ericsson.bss.cassandra.ecaudit.entry.PreparedAuditOperation.preparedWithValues(PreparedAuditOperation.java:102)
at com.ericsson.bss.cassandra.ecaudit.entry.PreparedAuditOperation.bindValues(PreparedAuditOperation.java:83)

This fix checks for non-zero size of columnSpecifications before proceeding further.