### PR TITLE
Clean up pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,12 +96,6 @@
                 <version>${cassandra.version}</version>
                 <scope>provided</scope>
             </dependency>
-            <dependency>
-                <groupId>org.apache.cassandra</groupId>
-                <artifactId>cassandra-thrift</artifactId>
-                <version>${cassandra.version}</version>
-                <scope>provided</scope>
-            </dependency>
 
             <dependency>
                 <groupId>commons-cli</groupId>


### PR DESCRIPTION
The thrift dependecy should have been removed since its not part of Cassandra 4.0