### PR TITLE
Update upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ ecAudit integrates with Apache Cassandra using its existing plug-in points.
 Official releases of ecAudit can be downloaded from Maven Central.
 Get the ecAudit flavor for your Cassandra version.
 
+[![ecAudit for Cassandra 4.1.<latest>](https://img.shields.io/maven-central/v/com.ericsson.bss.cassandra.ecaudit/ecaudit_c4.1.svg?label=ecAudit%20for%20Cassandra%204.1.<latest>)](https://search.maven.org/search?q=g:%22com.ericsson.bss.cassandra.ecaudit%22%20AND%20a:%22ecaudit_c4.1%22)
+[![ecAudit for Cassandra 4.0.<latest>](https://img.shields.io/maven-central/v/com.ericsson.bss.cassandra.ecaudit/ecaudit_c4.0.svg?label=ecAudit%20for%20Cassandra%204.0.<latest>)](https://search.maven.org/search?q=g:%22com.ericsson.bss.cassandra.ecaudit%22%20AND%20a:%22ecaudit_c4.0%22)
 [![ecAudit for Cassandra 3.11.<latest>](https://img.shields.io/maven-central/v/com.ericsson.bss.cassandra.ecaudit/ecaudit_c3.11.svg?label=ecAudit%20for%20Cassandra%203.11.<latest>)](https://search.maven.org/search?q=g:%22com.ericsson.bss.cassandra.ecaudit%22%20AND%20a:%22ecaudit_c3.11%22)
 
 For a detailed description of compatible Cassandra versions, refer to the [Cassandra Compatibility Matrix](doc/cassandra_compatibility.md).
@@ -59,10 +61,20 @@ The following flavors of ecAudit are no longer maintained.
 
 Install and configure ecAudit using the setup guide for your Cassandra version.
 
-* [ecAudit Setup Guide for Cassandra 3.11.\<latest>](https://github.com/Ericsson/ecaudit/blob/master/doc/setup.md)
+* [ecAudit Setup Guide for Cassandra 4.1.\<latest>](https://github.com/Ericsson/ecaudit/blob/master/doc/setup.md)
+* [ecAudit Setup Guide for Cassandra 4.0.\<latest>](https://github.com/Ericsson/ecaudit/blob/release/c4.0/doc/setup.md)
+* [ecAudit Setup Guide for Cassandra 3.11.\<latest>](https://github.com/Ericsson/ecaudit/blob/release/c3.11/doc/setup.md)
 * [ecAudit Setup Guide for Cassandra 3.0.\<latest>](https://github.com/Ericsson/ecaudit/blob/release/c3.0/doc/setup.md)
-* [ecAudit Setup Guide for Cassandra 3.0.11](https://github.com/Ericsson/ecaudit/blob/release/c3.0.11/doc/setup.md)
-* [ecAudit Setup Guide for Cassandra 2.2.\<latest>](https://github.com/Ericsson/ecaudit/blob/release/c2.2/doc/setup.md)
+
+
+### Upgrade
+
+Upgrade ecAudit using then upgrade guide for your Cassandra version
+
+* [ecAudit Upgrade Guide for Cassandra 4.1.\<latest>](https://github.com/Ericsson/ecaudit/blob/master/UPGRADING.md)
+* [ecAudit Upgrade Guide for Cassandra 4.0.\<latest>](https://github.com/Ericsson/ecaudit/blob/release/c4.0/UPGRADING.md)
+* [ecAudit Upgrade Guide for Cassandra 3.11.\<latest>](https://github.com/Ericsson/ecaudit/blob/release/c3.11/UPGRADING.md)
+* [ecAudit Upgrade Guide for Cassandra 3.0.\<latest>](https://github.com/Ericsson/ecaudit/blob/release/c3.0/doc/UPGRADING.md)
 
 
 ## Issues & Contributions

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Upgrade ecAudit using then upgrade guide for your Cassandra version
 * [ecAudit Upgrade Guide for Cassandra 4.1.\<latest>](https://github.com/Ericsson/ecaudit/blob/master/UPGRADING.md)
 * [ecAudit Upgrade Guide for Cassandra 4.0.\<latest>](https://github.com/Ericsson/ecaudit/blob/release/c4.0/UPGRADING.md)
 * [ecAudit Upgrade Guide for Cassandra 3.11.\<latest>](https://github.com/Ericsson/ecaudit/blob/release/c3.11/UPGRADING.md)
-* [ecAudit Upgrade Guide for Cassandra 3.0.\<latest>](https://github.com/Ericsson/ecaudit/blob/release/c3.0/doc/UPGRADING.md)
+* [ecAudit Upgrade Guide for Cassandra 3.0.\<latest>](https://github.com/Ericsson/ecaudit/blob/release/c3.0/UPGRADING.md)
 
 
 ## Issues & Contributions

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,17 +7,17 @@ Check out the [change log](CHANGES.md) for a full list of new features and fixes
 ## To version 3.0.x
 
 Administrators should be aware of the following changes when upgrading to version 3.0.0 or later.
-ecAudit can be upgraded to 3.0.x from version 2.x.x as long as these and any intermediate upgrade instructions are observed.
+ecAudit can be upgraded to 3.0.x from version 2.x.x as long as these and any intermediate upgrade instructions (described below) are followed.
 ecAudit 0.x.x or 1.x.x must be upgraded to 2.x.x before upgrading to 3.x.x.
 
 The command to drop legacy audit whitelist table is removed in 3.0.0, if ecAudit was updated from 0.x.x or 1.x.x to 2.x.x
-the legacy table must be dropped before upgrading to 3.x.x
+the legacy table must be dropped before upgrading to 3.x.x.
 
 
 ## To version 2.5.x
 
 Administrators should be aware of the following changes when upgrading to version 2.5.0 or later.
-ecAudit can be upgraded to 2.5.x from any previous major version as long as these and any intermediate upgrade instructions are observed.
+ecAudit can be upgraded to 2.5.x from any previous major version as long as these and any intermediate upgrade instructions (described below) are followed.
 
 As of version 2.5.0 the ```AuditPasswordAuthenticator``` is deprecated and should no longer be configured as the ```authenticator``` in ```cassandra.yaml```.
 Users should instead use the ```AuditAuthenticator``` which can delegate authentication operations to custom ```IAuthenticator``` implementation.
@@ -26,7 +26,7 @@ By default the new ```AuditAuthenticator``` will behave exactly like the ```Audi
 ## To version 2.1.x
 
 Administrators should be aware of the following changes when upgrading from version 0.x.x, 1.x.x or 2.0.x to 2.1.0 or later.
-ecAudit can be upgraded to 2.1.x from any previous major version as long as these and any intermediate upgrade instructions are observed.
+ecAudit can be upgraded to 2.1.x from any previous major version as long as these and any intermediate upgrade instructions (described below) are followed.
 
 As of version 2.1.0 ecAudit will read and use the configuration in the audit.yaml file stored in the Cassandra configuration directory.
 This directory is typically ```/etc/cassandra/conf/``` but may be different depending on your deployment.
@@ -38,7 +38,7 @@ Users who used this previously undocumented property should fix typo in their co
 ## To version 2.0.x
 
 Administrators should be aware of the following changes when upgrading from version 0.x.x or 1.x.x to 2.0.0 or later.
-ecAudit can be upgraded to 2.x.x from any previous major version as long as these and any intermediate upgrade instructions are observed.
+ecAudit can be upgraded to 2.x.x from any previous major version as long as these and any intermediate upgrade instructions (described below) are followed.
 
 As of version 2.0.0 ecAudit support whitelisting of specific operations on a resource.
 For example, it is possible to whitelisted a user for `SELECT` operations on a table, without whitelisting other operations such as the `MODIFY` operations on the same table.
@@ -85,7 +85,7 @@ cassandra@cqlsh> ALTER ROLE cassandra WITH OPTIONS = { 'drop_legacy_audit_whitel
 ## To version 1.x.x
 
 Administrators should be aware of the following changes when upgrading from version 0.x.x to 1.0.0 or later.
-ecAudit can be upgrade to 1.x.x from any 0.x.x version as long as the upgrade instructions below are observed.
+ecAudit can be upgrade to 1.x.x from any 0.x.x version as long as the upgrade instructions below are followed.
 
 ecAudit now provides a custom authorizer plug-in in.
 This is necessary in order to resolve issue #31,

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,16 @@ Below you'll find special instructions to consider when upgrading to a new versi
 Check out the [change log](CHANGES.md) for a full list of new features and fixes.
 
 
+## To version 3.0.x
+
+Administrators should be aware of the following changes when upgrading to version 3.0.0 or later.
+ecAudit can be upgraded to 3.0.x from version 2.x.x as long as these and any intermediate upgrade instructions are observed.
+ecAudit 0.x.x or 1.x.x must be upgraded to 2.x.x before upgrading to 3.x.x.
+
+The command to drop legacy audit whitelist table is removed in 3.0.0, if ecAudit was updated from 0.x.x or 1.x.x to 2.x.x
+the legacy table must be dropped before upgrading to 3.x.x
+
+
 ## To version 2.5.x
 
 Administrators should be aware of the following changes when upgrading to version 2.5.0 or later.


### PR DESCRIPTION
Update the upgrade guide to prepare for ecAudit 3.0.0 with Cassandra 4.1 support.